### PR TITLE
Fix assertion crash on weapon input for non-local players

### DIFF
--- a/Sources/Client/Player.cpp
+++ b/Sources/Client/Player.cpp
@@ -227,6 +227,8 @@ namespace spades {
 				}
 			} else if (tool == ToolWeapon && isLocal) {
 				weapon->SetShooting(newInput.primary);
+			} else if (tool == ToolWeapon) {
+				// non-local weapon player: no local simulation needed
 			} else {
 				SPAssert(false);
 			}


### PR DESCRIPTION

Player::SetWeaponInput handled ToolWeapon only for the local player, then hit SPAssert(false) in the catch-all for any other case. Since the server broadcasts WeaponInput packets (type 0x04) for all players, any remote player holding a weapon would trigger the assertion on every input update.

I believe it has been introduced in aac9135a ("refactor player alive state & minor corrections"), which restructured the tool/input handling but left the non-local weapon case unhandled.

The fix adds the missing branch : 
 for non-local weapon players, no local simulation is needed (weapon firing for remote players is driven by other packets), so it simply falls through to the weapInput = newInput store at the end of the function.