### PR TITLE
Add demo recording/replaying, closes #13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ OpenSpades.rc
 
 # vcpkg build artifacts
 vcpkg/
+
+# Demo recordings
+*.dem

--- a/README.md
+++ b/README.md
@@ -34,8 +34,38 @@ Some of the most important changes are:
 * Customizable HUD position and color.
 * Customizable crosshair & scope.
 * Same fog tint/color as the classic client (openspades applies a [bluish tint](https://github.com/yvt/openspades/blob/v0.1.3/Resources/Shaders/Fog.vs#L27) to the fog).
+* Demo recording compatible with [aos_replay](https://github.com/BR-/aos_replay) format.
 
 -- And a lot of other things that I forgot to mention here.
+
+## Demo Recording & Playback
+
+ZeroSpades supports recording and playing back gameplay demos using a format compatible with [aos_replay](https://github.com/BR-/aos_replay).
+
+### Recording
+
+Record gameplay from the command line:
+
+```bash
+# Record demos to mydemo_1.dem, mydemo_2.dem, etc. (one per game/map)
+openspades aos://server:port --record mydemo
+```
+
+Demos are saved with a numeric suffix for each game joined during the session.
+
+### Playback
+
+Play back demos directly in ZeroSpades:
+
+```bash
+# Play a demo file
+openspades /path/to/demo.dem
+
+# Or with the explicit flag
+openspades --replay /path/to/demo.dem
+```
+
+Demos can also be played back using the external [aos_replay](https://github.com/BR-/aos_replay) tool.
 
 ## How to Build/Install?
 See the [OpenSpades Building&Installing Guide](https://github.com/yvt/openspades#how-to-buildinstall)

--- a/Resources/Scripts/Gui/Client/ClientUI.as
+++ b/Resources/Scripts/Gui/Client/ClientUI.as
@@ -51,8 +51,8 @@ namespace spades {
 			@manager = spades::ui::UIManager(renderer, audioDevice);
 			@manager.RootElement.Font = fontManager.GuiFont;
 
-			@clientMenu = ClientMenu(this);
-			clientMenu.Bounds = manager.RootElement.Bounds;
+			// clientMenu is built lazily in EnterClientMenu() so that helper.IsDemoMode()
+			// reflects the demo flag, which isn't set until after Client::DoInit runs.
 
 			@chatLogWindow = ChatLogWindow(this);
 		}
@@ -96,7 +96,13 @@ namespace spades {
 		}
 		spades::ui::UIElement@ get_ActiveUI() property { return activeUI; }
 
-		void EnterClientMenu() { @ActiveUI = clientMenu; }
+		void EnterClientMenu() {
+			if (clientMenu is null) {
+				@clientMenu = ClientMenu(this);
+				clientMenu.Bounds = manager.RootElement.Bounds;
+			}
+			@ActiveUI = clientMenu;
+		}
 		void EnterTeamChatWindow() {
 			ClientChatWindow wnd(this, true);
 			@ActiveUI = wnd;

--- a/Resources/Scripts/Gui/Client/Menu.as
+++ b/Resources/Scripts/Gui/Client/Menu.as
@@ -68,7 +68,9 @@ namespace spades {
 			}
 			{
 				spades::ui::Button button(Manager);
-				button.Caption = _Tr("Client", "Disconnect");
+				button.Caption = helper.IsDemoMode()
+					? _Tr("Client", "Exit Demo")
+					: _Tr("Client", "Disconnect");
 				button.Bounds = AABB2(winX, winY + 96.0F, winW, 30.0F);
 				@button.Activated = spades::ui::EventHandler(this.OnDisconnect);
 				AddChild(button);

--- a/Resources/Scripts/Gui/MainScreen/DemoList.as
+++ b/Resources/Scripts/Gui/MainScreen/DemoList.as
@@ -1,0 +1,122 @@
+/*
+ Copyright (c) 2013 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.	 If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+namespace spades {
+
+	string StripDemoPath(string path) {
+		// Remove "Demos/" prefix
+		if (path.length > 6 and path.substr(0, 6) == "Demos/")
+			path = path.substr(6);
+		// Remove ".dem" suffix
+		if (path.length > 4 and path.substr(path.length - 4) == ".dem")
+			path = path.substr(0, path.length - 4);
+		return path;
+	}
+
+	class DemoListItem : spades::ui::ButtonBase {
+		string filename; // full path
+
+		DemoListItem(spades::ui::UIManager@ manager, string filename) {
+			super(manager);
+			this.filename = filename;
+		}
+
+		void Render() {
+			Renderer@ r = Manager.Renderer;
+			Vector2 pos = ScreenPosition;
+			Vector2 size = Size;
+
+			Vector4 bgcolor = Vector4(1.0F, 1.0F, 1.0F, 0.0F);
+			Vector4 fgcolor = Vector4(1.0F, 1.0F, 1.0F, 1.0F);
+
+			if (Pressed and Hover) {
+				bgcolor.w = 0.3F;
+			} else if (Hover) {
+				bgcolor.w = 0.15F;
+			}
+
+			r.ColorNP = bgcolor;
+			r.DrawImage(null, AABB2(pos.x + 1.0F, pos.y + 1.0F, size.x, size.y));
+
+			string display = StripDemoPath(filename);
+			Font.Draw(display, pos + Vector2(4.0F, 2.0F), 1.0F, fgcolor);
+		}
+	}
+
+	funcdef void DemoListItemEventHandler(DemoListModel@ sender, string filename);
+
+	class DemoListModel : spades::ui::ListViewModel {
+		spades::ui::UIManager@ manager;
+		string[] list;
+		DemoListItem@[] itemElements;
+
+		DemoListItemEventHandler@ ItemActivated;
+		DemoListItemEventHandler@ ItemDoubleClicked;
+
+		DemoListModel(spades::ui::UIManager@ manager, string[]@ list) {
+			@this.manager = manager;
+			this.list = list;
+
+			itemElements.resize(list.length);
+		}
+
+		int NumRows {
+			get { return int(list.length); }
+		}
+
+		private void OnItemClicked(spades::ui::UIElement@ sender) {
+			DemoListItem@ item = cast<DemoListItem>(sender);
+			if (ItemActivated !is null)
+				ItemActivated(this, item.filename);
+		}
+
+		private void OnItemDoubleClicked(spades::ui::UIElement@ sender) {
+			DemoListItem@ item = cast<DemoListItem>(sender);
+			if (ItemDoubleClicked !is null)
+				ItemDoubleClicked(this, item.filename);
+		}
+
+		spades::ui::UIElement@ CreateElement(int row) {
+			if (itemElements[row] is null) {
+				DemoListItem i(manager, list[row]);
+				@i.Activated = spades::ui::EventHandler(this.OnItemClicked);
+				@i.DoubleClicked = spades::ui::EventHandler(this.OnItemDoubleClicked);
+				@itemElements[row] = i;
+			}
+			return itemElements[row];
+		}
+
+		void RecycleElement(spades::ui::UIElement@ elem) {}
+	}
+
+	class DemoListHeader : spades::ui::UIElement {
+		string Text;
+		DemoListHeader(spades::ui::UIManager@ manager) { super(manager); }
+		void Render() {
+			Renderer@ r = Manager.Renderer;
+			Vector2 pos = ScreenPosition;
+			Vector2 size = Size;
+
+			Font.Draw(Text, pos + Vector2(2.0F, (size.y - Font.Measure(Text).y) * 0.5F), 1.0F,
+			          Vector4(1.0F, 1.0F, 1.0F, 1.0F));
+		}
+	}
+
+}

--- a/Resources/Scripts/Gui/MainScreen/DemoList.as
+++ b/Resources/Scripts/Gui/MainScreen/DemoList.as
@@ -20,6 +20,9 @@
 
 namespace spades {
 
+	// -------------------------------------------------------------------------
+	// Filename helpers
+
 	string StripDemoPath(string path) {
 		// Remove "Demos/" prefix
 		if (path.length > 6 and path.substr(0, 6) == "Demos/")
@@ -30,17 +33,145 @@ namespace spades {
 		return path;
 	}
 
-	class DemoListItem : spades::ui::ButtonBase {
-		string filename; // full path
+	bool DemoIsDigit(uint8 c) {
+		return c >= uint8(0x30) and c <= uint8(0x39); // '0'..'9'
+	}
 
-		DemoListItem(spades::ui::UIManager@ manager, string filename) {
+	// Replace underscores with spaces for display.
+	string DemoUnderscoreToSpace(string s) {
+		for (uint i = 0; i < s.length; i++) {
+			if (s[i] == uint8(0x5F)) // '_'
+				s[i] = uint8(0x20);  // ' '
+		}
+		return s;
+	}
+
+	// Capitalize the first letter of a string.
+	string DemoCapFirst(string s) {
+		if (s.length == 0)
+			return s;
+		if (s[0] >= uint8(0x61) and s[0] <= uint8(0x7A)) // 'a'..'z'
+			s[0] = s[0] - uint8(0x61) + uint8(0x41);     // to 'A'..'Z'
+		return s;
+	}
+
+	// Return a human-readable game mode label from a sanitized mode token.
+	string DemoFormatGameMode(string raw) {
+		if (raw == "ctf")   return "CTF";
+		if (raw == "tc")    return "TC";
+		if (raw == "arena") return "Arena";
+		if (raw == "game")  return "Game";
+		return DemoCapFirst(raw);
+	}
+
+	// Split a string on '-' (ASCII 0x2D) and return the parts.
+	string[] DemoSplitByDash(string s) {
+		string[] result;
+		int start = 0;
+		for (int i = 0; i <= int(s.length); i++) {
+			if (i == int(s.length) or s[i] == uint8(0x2D)) {
+				result.insertLast(s.substr(start, i - start));
+				start = i + 1;
+			}
+		}
+		return result;
+	}
+
+	// -------------------------------------------------------------------------
+	// Parsed demo metadata
+
+	class DemoInfo {
+		bool structured;    // false when the filename doesn't follow the expected pattern
+		string displayName; // stripped filename, always set
+		string timestamp;   // "YYYY-MM-DD HH:MM" — only when structured is true
+		string gameMode;    // display-ready mode, e.g. "CTF" — only when structured
+		string mapName;     // display-ready map name — only when structured
+		string serverName;  // display-ready server name — only when structured
+
+		DemoInfo() { structured = false; }
+	}
+
+	// Parse a full demo path (e.g. "Demos/2025-03-14-14-30-ctf-dust-myserver.dem")
+	// into a DemoInfo.  Falls back to displayName-only when the name does not
+	// conform to the expected YYYY-MM-DD-HH-MM[-mode[-map[-server]]] format.
+	DemoInfo ParseDemoFilename(string path) {
+		DemoInfo info;
+		info.displayName = StripDemoPath(path);
+		string name = info.displayName;
+
+		// The timestamp prefix occupies exactly 16 characters:
+		//   YYYY-MM-DD-HH-MM  (positions 0-15)
+		// followed by either end-of-string or a '-' separator.
+		if (name.length >= 16) {
+			bool valid =
+				DemoIsDigit(name[0])  and DemoIsDigit(name[1])  and
+				DemoIsDigit(name[2])  and DemoIsDigit(name[3])  and
+				name[4]  == uint8(0x2D) and // '-'
+				DemoIsDigit(name[5])  and DemoIsDigit(name[6])  and
+				name[7]  == uint8(0x2D) and
+				DemoIsDigit(name[8])  and DemoIsDigit(name[9])  and
+				name[10] == uint8(0x2D) and
+				DemoIsDigit(name[11]) and DemoIsDigit(name[12]) and
+				name[13] == uint8(0x2D) and
+				DemoIsDigit(name[14]) and DemoIsDigit(name[15]);
+
+			if (valid and (name.length == 16 or name[16] == uint8(0x2D))) {
+				// Format as "YYYY-MM-DD HH:MM"
+				info.timestamp = name.substr(0, 4) + "-" +
+				                 name.substr(5, 2) + "-" +
+				                 name.substr(8, 2) + " " +
+				                 name.substr(11, 2) + ":" +
+				                 name.substr(14, 2);
+
+				// Parse optional context: mode[-map[-server]]
+				if (name.length > 17) {
+					string context = name.substr(17);
+					string[] parts = DemoSplitByDash(context);
+
+					if (parts.length >= 1 and parts[0].length > 0)
+						info.gameMode = DemoFormatGameMode(parts[0]);
+					if (parts.length >= 2 and parts[1].length > 0)
+						info.mapName = DemoUnderscoreToSpace(parts[1]);
+					if (parts.length >= 3) {
+						// Remaining parts form the server name (joined with space).
+						string server = parts[2];
+						for (uint i = 3; i < parts.length; i++)
+							server += "_" + parts[i];
+						info.serverName = DemoUnderscoreToSpace(server);
+					}
+				}
+
+				info.structured = true;
+			}
+		}
+
+		return info;
+	}
+
+	// -------------------------------------------------------------------------
+	// List item
+
+	class DemoListItem : spades::ui::ButtonBase {
+		string filename;    // full path
+		DemoInfo info;      // parsed metadata
+		float colDateWidth;
+		float colModeWidth;
+		float colMapWidth;
+
+		DemoListItem(spades::ui::UIManager@ manager, string filename,
+		             DemoInfo info,
+		             float colDateWidth, float colModeWidth, float colMapWidth) {
 			super(manager);
-			this.filename = filename;
+			this.filename    = filename;
+			this.info        = info;
+			this.colDateWidth = colDateWidth;
+			this.colModeWidth = colModeWidth;
+			this.colMapWidth  = colMapWidth;
 		}
 
 		void Render() {
 			Renderer@ r = Manager.Renderer;
-			Vector2 pos = ScreenPosition;
+			Vector2 pos  = ScreenPosition;
 			Vector2 size = Size;
 
 			Vector4 bgcolor = Vector4(1.0F, 1.0F, 1.0F, 0.0F);
@@ -55,8 +186,18 @@ namespace spades {
 			r.ColorNP = bgcolor;
 			r.DrawImage(null, AABB2(pos.x + 1.0F, pos.y + 1.0F, size.x, size.y));
 
-			string display = StripDemoPath(filename);
-			Font.Draw(display, pos + Vector2(4.0F, 2.0F), 1.0F, fgcolor);
+			if (info.structured) {
+				// Column order (left to right): Server | Map | Mode | Date
+				// Server takes whatever space is left; the three rightmost columns are fixed-width.
+				float serverWidth = size.x - colMapWidth - colModeWidth - colDateWidth;
+				Font.Draw(info.serverName, pos + Vector2(4.0F, 2.0F), 1.0F, fgcolor);
+				Font.Draw(info.mapName,    pos + Vector2(serverWidth + 4.0F, 2.0F), 1.0F, fgcolor);
+				Font.Draw(info.gameMode,   pos + Vector2(serverWidth + colMapWidth + 4.0F, 2.0F), 1.0F, fgcolor);
+				Font.Draw(info.timestamp,  pos + Vector2(serverWidth + colMapWidth + colModeWidth + 4.0F, 2.0F), 1.0F, fgcolor);
+			} else {
+				// Filename does not match the structured format; display it as-is.
+				Font.Draw(info.displayName, pos + Vector2(4.0F, 2.0F), 1.0F, fgcolor);
+			}
 		}
 	}
 
@@ -66,13 +207,20 @@ namespace spades {
 		spades::ui::UIManager@ manager;
 		string[] list;
 		DemoListItem@[] itemElements;
+		float colDateWidth;
+		float colModeWidth;
+		float colMapWidth;
 
 		DemoListItemEventHandler@ ItemActivated;
 		DemoListItemEventHandler@ ItemDoubleClicked;
 
-		DemoListModel(spades::ui::UIManager@ manager, string[]@ list) {
+		DemoListModel(spades::ui::UIManager@ manager, string[]@ list,
+		              float colDateWidth, float colModeWidth, float colMapWidth) {
 			@this.manager = manager;
 			this.list = list;
+			this.colDateWidth = colDateWidth;
+			this.colModeWidth = colModeWidth;
+			this.colMapWidth  = colMapWidth;
 
 			itemElements.resize(list.length);
 		}
@@ -95,8 +243,9 @@ namespace spades {
 
 		spades::ui::UIElement@ CreateElement(int row) {
 			if (itemElements[row] is null) {
-				DemoListItem i(manager, list[row]);
-				@i.Activated = spades::ui::EventHandler(this.OnItemClicked);
+				DemoInfo info = ParseDemoFilename(list[row]);
+				DemoListItem i(manager, list[row], info, colDateWidth, colModeWidth, colMapWidth);
+				@i.Activated     = spades::ui::EventHandler(this.OnItemClicked);
 				@i.DoubleClicked = spades::ui::EventHandler(this.OnItemDoubleClicked);
 				@itemElements[row] = i;
 			}
@@ -106,12 +255,15 @@ namespace spades {
 		void RecycleElement(spades::ui::UIElement@ elem) {}
 	}
 
+	// -------------------------------------------------------------------------
+	// Column header
+
 	class DemoListHeader : spades::ui::UIElement {
 		string Text;
 		DemoListHeader(spades::ui::UIManager@ manager) { super(manager); }
 		void Render() {
 			Renderer@ r = Manager.Renderer;
-			Vector2 pos = ScreenPosition;
+			Vector2 pos  = ScreenPosition;
 			Vector2 size = Size;
 
 			Font.Draw(Text, pos + Vector2(2.0F, (size.y - Font.Measure(Text).y) * 0.5F), 1.0F,

--- a/Resources/Scripts/Gui/MainScreen/DemoList.as
+++ b/Resources/Scripts/Gui/MainScreen/DemoList.as
@@ -37,7 +37,7 @@ namespace spades {
 		return c >= uint8(0x30) and c <= uint8(0x39); // '0'..'9'
 	}
 
-	// Replace underscores with spaces for display.
+	// Replace underscores with spaces for display (unescape '-'-encoded fields).
 	string DemoUnderscoreToSpace(string s) {
 		for (uint i = 0; i < s.length; i++) {
 			if (s[i] == uint8(0x5F)) // '_'
@@ -77,6 +77,17 @@ namespace spades {
 		return result;
 	}
 
+	// Format a file size in bytes as a human-readable string.
+	string DemoFormatFileSize(int64 bytes) {
+		if (bytes < 0)
+			return "";
+		if (bytes < 1024)
+			return bytes + " B";
+		if (bytes < 1024 * 1024)
+			return (bytes / 1024) + " KB";
+		return (bytes / (1024 * 1024)) + " MB";
+	}
+
 	// -------------------------------------------------------------------------
 	// Parsed demo metadata
 
@@ -87,17 +98,25 @@ namespace spades {
 		string gameMode;    // display-ready mode, e.g. "CTF" — only when structured
 		string mapName;     // display-ready map name — only when structured
 		string serverName;  // display-ready server name — only when structured
+		string fileSize;    // human-readable size, e.g. "1 MB" — always set
 
 		DemoInfo() { structured = false; }
 	}
 
-	// Parse a full demo path (e.g. "Demos/2025-03-14-14-30-ctf-dust-myserver.dem")
+	// Parse a full demo path (e.g. "Demos/2025-03-14-14-30-myserver-dust-ctf.dem")
 	// into a DemoInfo.  Falls back to displayName-only when the name does not
-	// conform to the expected YYYY-MM-DD-HH-MM[-mode[-map[-server]]] format.
-	DemoInfo ParseDemoFilename(string path) {
+	// conform to the expected YYYY-MM-DD-HH-MM[-server[-map[-gamemode]]] format.
+	//
+	// Escaping: '-' is the field separator and is never emitted within a field
+	// (SanitizeComponent replaces it with '_').  DemoUnderscoreToSpace reverses
+	// this for display.
+	DemoInfo ParseDemoFilename(string path, MainScreenHelper@ helper) {
 		DemoInfo info;
 		info.displayName = StripDemoPath(path);
 		string name = info.displayName;
+
+		int64 sz = helper.GetDemoFileSize(path);
+		info.fileSize = DemoFormatFileSize(sz);
 
 		// The timestamp prefix occupies exactly 16 characters:
 		//   YYYY-MM-DD-HH-MM  (positions 0-15)
@@ -123,21 +142,29 @@ namespace spades {
 				                 name.substr(11, 2) + ":" +
 				                 name.substr(14, 2);
 
-				// Parse optional context: mode[-map[-server]]
+				// Parse optional context: server[-map[-gamemode]]
 				if (name.length > 17) {
 					string context = name.substr(17);
 					string[] parts = DemoSplitByDash(context);
 
-					if (parts.length >= 1 and parts[0].length > 0)
+					// server: all parts except the last two
+					// map:    second-to-last part
+					// mode:   last part
+					// Minimum: just gamemode (1 part), server+gamemode (2 parts),
+					// server+map+gamemode (3+ parts).
+					if (parts.length == 1) {
 						info.gameMode = DemoFormatGameMode(parts[0]);
-					if (parts.length >= 2 and parts[1].length > 0)
-						info.mapName = DemoUnderscoreToSpace(parts[1]);
-					if (parts.length >= 3) {
-						// Remaining parts form the server name (joined with space).
-						string server = parts[2];
-						for (uint i = 3; i < parts.length; i++)
-							server += "_" + parts[i];
+					} else if (parts.length == 2) {
+						info.serverName = DemoUnderscoreToSpace(parts[0]);
+						info.gameMode   = DemoFormatGameMode(parts[1]);
+					} else {
+						// server = parts[0..n-3] joined with space, map = parts[n-2], mode = parts[n-1]
+						string server = parts[0];
+						for (uint i = 1; i < parts.length - 2; i++)
+							server += " " + parts[i];
 						info.serverName = DemoUnderscoreToSpace(server);
+						info.mapName    = DemoUnderscoreToSpace(parts[parts.length - 2]);
+						info.gameMode   = DemoFormatGameMode(parts[parts.length - 1]);
 					}
 				}
 
@@ -157,16 +184,18 @@ namespace spades {
 		float colDateWidth;
 		float colModeWidth;
 		float colMapWidth;
+		float colSizeWidth;
 
 		DemoListItem(spades::ui::UIManager@ manager, string filename,
 		             DemoInfo info,
-		             float colDateWidth, float colModeWidth, float colMapWidth) {
+		             float colDateWidth, float colModeWidth, float colMapWidth, float colSizeWidth) {
 			super(manager);
-			this.filename    = filename;
-			this.info        = info;
+			this.filename     = filename;
+			this.info         = info;
 			this.colDateWidth = colDateWidth;
 			this.colModeWidth = colModeWidth;
 			this.colMapWidth  = colMapWidth;
+			this.colSizeWidth = colSizeWidth;
 		}
 
 		void Render() {
@@ -187,13 +216,20 @@ namespace spades {
 			r.DrawImage(null, AABB2(pos.x + 1.0F, pos.y + 1.0F, size.x, size.y));
 
 			if (info.structured) {
-				// Column order (left to right): Server | Map | Mode | Date
-				// Server takes whatever space is left; the three rightmost columns are fixed-width.
-				float serverWidth = size.x - colMapWidth - colModeWidth - colDateWidth;
-				Font.Draw(info.serverName, pos + Vector2(4.0F, 2.0F), 1.0F, fgcolor);
-				Font.Draw(info.mapName,    pos + Vector2(serverWidth + 4.0F, 2.0F), 1.0F, fgcolor);
-				Font.Draw(info.gameMode,   pos + Vector2(serverWidth + colMapWidth + 4.0F, 2.0F), 1.0F, fgcolor);
-				Font.Draw(info.timestamp,  pos + Vector2(serverWidth + colMapWidth + colModeWidth + 4.0F, 2.0F), 1.0F, fgcolor);
+				// Column order (left to right): Server | Map | Mode | Timestamp | Size
+				// Server is variable-width; the four rightmost columns are fixed-width.
+				float fixedRight = colMapWidth + colModeWidth + colDateWidth + colSizeWidth;
+				float serverWidth = size.x - fixedRight;
+				float x = pos.x + 4.0F;
+				Font.Draw(info.serverName, Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
+				x = pos.x + serverWidth + 4.0F;
+				Font.Draw(info.mapName,    Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
+				x += colMapWidth;
+				Font.Draw(info.gameMode,   Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
+				x += colModeWidth;
+				Font.Draw(info.timestamp,  Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
+				x += colDateWidth;
+				Font.Draw(info.fileSize,   Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
 			} else {
 				// Filename does not match the structured format; display it as-is.
 				Font.Draw(info.displayName, pos + Vector2(4.0F, 2.0F), 1.0F, fgcolor);
@@ -205,22 +241,27 @@ namespace spades {
 
 	class DemoListModel : spades::ui::ListViewModel {
 		spades::ui::UIManager@ manager;
+		MainScreenHelper@ helper;
 		string[] list;
 		DemoListItem@[] itemElements;
 		float colDateWidth;
 		float colModeWidth;
 		float colMapWidth;
+		float colSizeWidth;
 
 		DemoListItemEventHandler@ ItemActivated;
 		DemoListItemEventHandler@ ItemDoubleClicked;
 
-		DemoListModel(spades::ui::UIManager@ manager, string[]@ list,
-		              float colDateWidth, float colModeWidth, float colMapWidth) {
-			@this.manager = manager;
-			this.list = list;
+		DemoListModel(spades::ui::UIManager@ manager, MainScreenHelper@ helper,
+		              string[]@ list,
+		              float colDateWidth, float colModeWidth, float colMapWidth, float colSizeWidth) {
+			@this.manager    = manager;
+			@this.helper     = helper;
+			this.list        = list;
 			this.colDateWidth = colDateWidth;
 			this.colModeWidth = colModeWidth;
 			this.colMapWidth  = colMapWidth;
+			this.colSizeWidth = colSizeWidth;
 
 			itemElements.resize(list.length);
 		}
@@ -243,8 +284,8 @@ namespace spades {
 
 		spades::ui::UIElement@ CreateElement(int row) {
 			if (itemElements[row] is null) {
-				DemoInfo info = ParseDemoFilename(list[row]);
-				DemoListItem i(manager, list[row], info, colDateWidth, colModeWidth, colMapWidth);
+				DemoInfo info = ParseDemoFilename(list[row], helper);
+				DemoListItem i(manager, list[row], info, colDateWidth, colModeWidth, colMapWidth, colSizeWidth);
 				@i.Activated     = spades::ui::EventHandler(this.OnItemClicked);
 				@i.DoubleClicked = spades::ui::EventHandler(this.OnItemDoubleClicked);
 				@itemElements[row] = i;

--- a/Resources/Scripts/Gui/MainScreen/DemoList.as
+++ b/Resources/Scripts/Gui/MainScreen/DemoList.as
@@ -190,10 +190,12 @@ namespace spades {
 		float colModeWidth;
 		float colMapWidth;
 		float colSizeWidth;
+		float totalWidth;
 
 		DemoListItem(spades::ui::UIManager@ manager, string filename,
 		             DemoInfo info,
-		             float colDateWidth, float colModeWidth, float colMapWidth, float colSizeWidth) {
+		             float colDateWidth, float colModeWidth, float colMapWidth, float colSizeWidth,
+		             float totalWidth) {
 			super(manager);
 			this.filename     = filename;
 			this.info         = info;
@@ -201,6 +203,7 @@ namespace spades {
 			this.colModeWidth = colModeWidth;
 			this.colMapWidth  = colMapWidth;
 			this.colSizeWidth = colSizeWidth;
+			this.totalWidth   = totalWidth;
 		}
 
 		void Render() {
@@ -223,11 +226,14 @@ namespace spades {
 			if (info.structured) {
 				// Column order (left to right): Server | Map | Mode | Timestamp | Size
 				// Server is variable-width; the four rightmost columns are fixed-width.
+				// Use totalWidth (= contentsWidth from the layout) so that fixed-column
+				// positions match the headers, which are also sized from contentsWidth.
+				// (size.x is narrower by the ListView scrollbar width.)
 				float fixedRight = colMapWidth + colModeWidth + colDateWidth + colSizeWidth;
-				float serverWidth = size.x - fixedRight;
-				float x = pos.x + 4.0F;
+				float serverWidth = totalWidth - fixedRight;
+				float x = pos.x + 2.0F;
 				Font.Draw(info.serverName, Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
-				x = pos.x + serverWidth + 4.0F;
+				x = pos.x + serverWidth + 2.0F;
 				Font.Draw(info.mapName,    Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
 				x += colMapWidth;
 				Font.Draw(info.gameMode,   Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
@@ -237,7 +243,7 @@ namespace spades {
 				Font.Draw(info.fileSize,   Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
 			} else {
 				// Filename does not match the structured format; display it as-is.
-				Font.Draw(info.displayName, pos + Vector2(4.0F, 2.0F), 1.0F, fgcolor);
+				Font.Draw(info.displayName, pos + Vector2(2.0F, 2.0F), 1.0F, fgcolor);
 			}
 		}
 	}
@@ -253,13 +259,15 @@ namespace spades {
 		float colModeWidth;
 		float colMapWidth;
 		float colSizeWidth;
+		float totalWidth;
 
 		DemoListItemEventHandler@ ItemActivated;
 		DemoListItemEventHandler@ ItemDoubleClicked;
 
 		DemoListModel(spades::ui::UIManager@ manager, MainScreenHelper@ helper,
 		              string[]@ list,
-		              float colDateWidth, float colModeWidth, float colMapWidth, float colSizeWidth) {
+		              float colDateWidth, float colModeWidth, float colMapWidth, float colSizeWidth,
+		              float totalWidth) {
 			@this.manager    = manager;
 			@this.helper     = helper;
 			this.list        = list;
@@ -267,6 +275,7 @@ namespace spades {
 			this.colModeWidth = colModeWidth;
 			this.colMapWidth  = colMapWidth;
 			this.colSizeWidth = colSizeWidth;
+			this.totalWidth   = totalWidth;
 
 			itemElements.resize(list.length);
 		}
@@ -290,7 +299,7 @@ namespace spades {
 		spades::ui::UIElement@ CreateElement(int row) {
 			if (itemElements[row] is null) {
 				DemoInfo info = ParseDemoFilename(list[row], helper);
-				DemoListItem i(manager, list[row], info, colDateWidth, colModeWidth, colMapWidth, colSizeWidth);
+				DemoListItem i(manager, list[row], info, colDateWidth, colModeWidth, colMapWidth, colSizeWidth, totalWidth);
 				@i.Activated     = spades::ui::EventHandler(this.OnItemClicked);
 				@i.DoubleClicked = spades::ui::EventHandler(this.OnItemDoubleClicked);
 				@itemElements[row] = i;

--- a/Resources/Scripts/Gui/MainScreen/DemoList.as
+++ b/Resources/Scripts/Gui/MainScreen/DemoList.as
@@ -24,9 +24,14 @@ namespace spades {
 	// Filename helpers
 
 	string StripDemoPath(string path) {
-		// Remove "Demos/" prefix
-		if (path.length > 6 and path.substr(0, 6) == "Demos/")
-			path = path.substr(6);
+		// Remove everything up to and including the last '/' (handles both
+		// relative "Demos/name.dem" and absolute "/some/dir/Demos/name.dem").
+		for (int i = int(path.length) - 1; i >= 0; i--) {
+			if (path[i] == uint8(0x2F)) { // '/'
+				path = path.substr(i + 1);
+				break;
+			}
+		}
 		// Remove ".dem" suffix
 		if (path.length > 4 and path.substr(path.length - 4) == ".dem")
 			path = path.substr(0, path.length - 4);

--- a/Resources/Scripts/Gui/MainScreen/DemoList.as
+++ b/Resources/Scripts/Gui/MainScreen/DemoList.as
@@ -1,20 +1,21 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2026 Francois ND
+ based on code of OpenSpades (c) yvt 2013.
 
- This file is part of OpenSpades.
+ This file is part of ZeroSpades, a fork of OpenSpades.
 
- OpenSpades is free software: you can redistribute it and/or modify
+ ZeroSpades is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- OpenSpades is distributed in the hope that it will be useful,
+ ZeroSpades is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with OpenSpades.	 If not, see <http://www.gnu.org/licenses/>.
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
 

--- a/Resources/Scripts/Gui/MainScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/MainScreen/MainMenu.as
@@ -98,6 +98,7 @@ namespace spades {
 		private float demoDateColWidth;
 		private float demoModeColWidth;
 		private float demoMapColWidth;
+		private float demoSizeColWidth;
 
 		private ConfigItem cg_protocolVersion("cg_protocolVersion", "3");
 		private ConfigItem cg_lastQuickConnectHost("cg_lastQuickConnectHost", "127.0.0.1");
@@ -112,6 +113,7 @@ namespace spades {
 			demoDateColWidth = 130.0F;
 			demoModeColWidth = 65.0F;
 			demoMapColWidth  = 185.0F;
+			demoSizeColWidth = 70.0F;
 
 			float sw = Manager.ScreenWidth;
 			float sh = Manager.ScreenHeight;
@@ -306,31 +308,43 @@ namespace spades {
 					demoPanel.AddChild(playButton);
 				}
 				{
-					// Column order: Server | Map | Mode | Date
-					// Server is variable-width; the three rightmost columns are fixed.
-					float serverColWidth = contentsWidth - demoMapColWidth - demoModeColWidth - demoDateColWidth;
+					// Column order: Server | Map | Mode | Timestamp | Size
+					// Server is variable-width; the four rightmost columns are fixed.
+					float fixedRight = demoMapColWidth + demoModeColWidth + demoDateColWidth + demoSizeColWidth;
+					float serverColWidth = contentsWidth - fixedRight;
+					float x = contentsLeft;
 					{
 						DemoListHeader header(Manager);
-						header.Bounds = AABB2(contentsLeft, headerPos, serverColWidth, headerHeight);
+						header.Bounds = AABB2(x, headerPos, serverColWidth, headerHeight);
 						header.Text = _Tr("MainScreen", "Server");
 						demoPanel.AddChild(header);
+						x += serverColWidth;
 					}
 					{
 						DemoListHeader header(Manager);
-						header.Bounds = AABB2(contentsLeft + serverColWidth, headerPos, demoMapColWidth, headerHeight);
+						header.Bounds = AABB2(x, headerPos, demoMapColWidth, headerHeight);
 						header.Text = _Tr("MainScreen", "Map");
 						demoPanel.AddChild(header);
+						x += demoMapColWidth;
 					}
 					{
 						DemoListHeader header(Manager);
-						header.Bounds = AABB2(contentsLeft + serverColWidth + demoMapColWidth, headerPos, demoModeColWidth, headerHeight);
+						header.Bounds = AABB2(x, headerPos, demoModeColWidth, headerHeight);
 						header.Text = _Tr("MainScreen", "Mode");
 						demoPanel.AddChild(header);
+						x += demoModeColWidth;
 					}
 					{
 						DemoListHeader header(Manager);
-						header.Bounds = AABB2(contentsLeft + serverColWidth + demoMapColWidth + demoModeColWidth, headerPos, demoDateColWidth, headerHeight);
-						header.Text = _Tr("MainScreen", "Date");
+						header.Bounds = AABB2(x, headerPos, demoDateColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Timestamp");
+						demoPanel.AddChild(header);
+						x += demoDateColWidth;
+					}
+					{
+						DemoListHeader header(Manager);
+						header.Bounds = AABB2(x, headerPos, demoSizeColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Size");
 						demoPanel.AddChild(header);
 					}
 				}
@@ -403,7 +417,7 @@ namespace spades {
 			string[] reversed;
 			for (int i = int(demos.length) - 1; i >= 0; i--)
 				reversed.insertLast(demos[i]);
-			DemoListModel model(Manager, reversed, demoDateColWidth, demoModeColWidth, demoMapColWidth);
+			DemoListModel model(Manager, helper, reversed, demoDateColWidth, demoModeColWidth, demoMapColWidth, demoSizeColWidth);
 			@demoList.Model = model;
 			@model.ItemActivated = DemoListItemEventHandler(this.DemoListItemActivated);
 			@model.ItemDoubleClicked = DemoListItemEventHandler(this.DemoListItemDoubleClicked);

--- a/Resources/Scripts/Gui/MainScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/MainScreen/MainMenu.as
@@ -20,6 +20,7 @@
 
 #include "CreateProfileScreen.as"
 #include "ServerList.as"
+#include "DemoList.as"
 
 namespace spades {
 
@@ -58,6 +59,12 @@ namespace spades {
 		return text.findFirst(pattern) >= 0;
 	}
 
+	// Transparent container panel used for tab switching
+	class TabPanel : spades::ui::UIElement {
+		TabPanel(spades::ui::UIManager@ manager) { super(manager); }
+		void Render() { UIElement::Render(); }
+	}
+
 	class MainScreenMainMenu : spades::ui::UIElement {
 		MainScreenUI@ ui;
 		MainScreenHelper@ helper;
@@ -70,7 +77,7 @@ namespace spades {
 		spades::ui::Button@ filterProtocol4Button;
 		spades::ui::Button@ filterEmptyButton;
 		spades::ui::Button@ filterFullButton;
-		spades::ui::Field@ filterField; // Use addressField instead?
+		spades::ui::Field@ filterField;
 
 		spades::ui::ListView@ serverList;
 		MainScreenServerListLoadingView@ loadingView;
@@ -81,6 +88,12 @@ namespace spades {
 		int serverListUpdateTimer = 5;
 		string selectedMapName;
 
+		// Demo tab state
+		TabPanel@ demoPanel;
+		spades::ui::ListView@ demoList;
+		DemoListModel@ currentDemoListModel;
+		string selectedDemoPath;
+
 		private ConfigItem cg_protocolVersion("cg_protocolVersion", "3");
 		private ConfigItem cg_lastQuickConnectHost("cg_lastQuickConnectHost", "127.0.0.1");
 		private ConfigItem cg_serverlistSort("cg_serverlistSort", "16385");
@@ -89,6 +102,7 @@ namespace spades {
 			super(ui.manager);
 			@this.ui = ui;
 			@this.helper = ui.helper;
+			@this.Font = ui.fontManager.GuiFont;
 
 			float sw = Manager.ScreenWidth;
 			float sh = Manager.ScreenHeight;
@@ -100,8 +114,10 @@ namespace spades {
 
 			float contentsLeft = (sw - contentsWidth) * 0.5F;
 			float footerPos = sh - 50.0F;
-			float headerPos = 246.0F;
+			float tabStripPos = 232.0F;
+			float headerPos = 260.0F;
 			float headerHeight = 24.0F;
+			float listPos = headerPos + headerHeight;
 
 			// adjust based on screen width
 			float scaleF = Min(sw / maxContentsWidth, 1.0F);
@@ -111,46 +127,202 @@ namespace spades {
 			float protocolOffsetX = 640.0F * scaleF;
 			float pingOffsetX = 680.0F * scaleF;
 
+			// --- Tab strip (always visible) ---
 			{
-				spades::ui::Button button(Manager);
-				button.Caption = _Tr("MainScreen", "Connect");
-				button.HotKeyText = _Tr("Client", "[Enter]");
-				button.Bounds = AABB2(contentsLeft + contentsWidth - 150.0F, 200.0F, 150.0F, 30.0F);
-				@button.Activated = spades::ui::EventHandler(this.OnConnectPressed);
-				AddChild(button);
+				TabPanel serverPanel(Manager);
+				serverPanel.Bounds = AABB2(0.0F, 0.0F, sw, sh);
+
+				@demoPanel = TabPanel(Manager);
+				demoPanel.Bounds = AABB2(0.0F, 0.0F, sw, sh);
+				demoPanel.Visible = false;
+
+				// --- Server panel contents ---
+				{
+					spades::ui::Button button(Manager);
+					button.Caption = _Tr("MainScreen", "Connect");
+					button.HotKeyText = _Tr("Client", "[Enter]");
+					button.Bounds = AABB2(contentsLeft + contentsWidth - 150.0F, 200.0F, 150.0F, 30.0F);
+					@button.Activated = spades::ui::EventHandler(this.OnConnectPressed);
+					serverPanel.AddChild(button);
+				}
+				{
+					@addressField = spades::ui::Field(Manager);
+					addressField.Bounds = AABB2(contentsLeft, 200.0F, contentsWidth - 270.0F, 30.0F);
+					addressField.Placeholder = _Tr("MainScreen", "Quick Connect");
+					addressField.Text = cg_lastQuickConnectHost.StringValue;
+					@addressField.Changed = spades::ui::EventHandler(this.OnAddressChanged);
+					serverPanel.AddChild(addressField);
+				}
+				{
+					RefreshButton button(Manager);
+					button.Bounds = AABB2(contentsLeft + contentsWidth - 270.0F, 200.0F, 30.0F, 30.0F);
+					@button.Activated = spades::ui::EventHandler(this.OnRefreshServerListPressed);
+					serverPanel.AddChild(button);
+				}
+				{
+					@protocol3Button = ProtocolButton(Manager);
+					protocol3Button.Bounds = AABB2(contentsLeft + contentsWidth - 240.0F + 6.0F, 200.0F, 40.0F, 30.0F);
+					protocol3Button.Caption = _Tr("MainScreen", "0.75");
+					@protocol3Button.Activated = spades::ui::EventHandler(this.OnProtocol3Pressed);
+					protocol3Button.Toggle = true;
+					protocol3Button.Toggled = cg_protocolVersion.IntValue == 3;
+					serverPanel.AddChild(protocol3Button);
+				}
+				{
+					@protocol4Button = ProtocolButton(Manager);
+					protocol4Button.Bounds = AABB2(contentsLeft + contentsWidth - 200.0F + 6.0F, 200.0F, 40.0F, 30.0F);
+					protocol4Button.Caption = _Tr("MainScreen", "0.76");
+					@protocol4Button.Activated = spades::ui::EventHandler(this.OnProtocol4Pressed);
+					protocol4Button.Toggle = true;
+					protocol4Button.Toggled = cg_protocolVersion.IntValue == 4;
+					serverPanel.AddChild(protocol4Button);
+				}
+				{
+					@serverList = spades::ui::ListView(Manager);
+					serverList.Bounds = AABB2(contentsLeft, listPos, contentsWidth, footerPos - listPos - 14.0F);
+					serverPanel.AddChild(serverList);
+				}
+				{
+					ServerListHeader header(Manager);
+					header.Bounds = AABB2(contentsLeft, headerPos, slotsOffsetX, headerHeight);
+					header.Text = _Tr("MainScreen", "Server Name");
+					@header.Activated = spades::ui::EventHandler(this.SortServerListByName);
+					serverPanel.AddChild(header);
+				}
+				{
+					ServerListHeader header(Manager);
+					header.Bounds = AABB2(contentsLeft + slotsOffsetX, headerPos, mapNameOffsetX - slotsOffsetX, headerHeight);
+					header.Text = _Tr("MainScreen", "Slots");
+					header.Alignment = Vector2(0.5F, 0.5F);
+					@header.Activated = spades::ui::EventHandler(this.SortServerListByNumPlayers);
+					serverPanel.AddChild(header);
+				}
+				{
+					ServerListHeader header(Manager);
+					header.Bounds = AABB2(contentsLeft + mapNameOffsetX, headerPos, gameModeOffsetX - mapNameOffsetX, headerHeight);
+					header.Text = _Tr("MainScreen", "Map Name");
+					@header.Activated = spades::ui::EventHandler(this.SortServerListByMapName);
+					serverPanel.AddChild(header);
+				}
+				{
+					ServerListHeader header(Manager);
+					header.Bounds = AABB2(contentsLeft + gameModeOffsetX, headerPos, protocolOffsetX - gameModeOffsetX, headerHeight);
+					header.Text = _Tr("MainScreen", "Game Mode");
+					header.Alignment = Vector2(0.5F, 0.5F);
+					@header.Activated = spades::ui::EventHandler(this.SortServerListByGameMode);
+					serverPanel.AddChild(header);
+				}
+				{
+					ServerListHeader header(Manager);
+					header.Bounds = AABB2(contentsLeft + protocolOffsetX, headerPos, pingOffsetX - protocolOffsetX, headerHeight);
+					header.Text = _Tr("MainScreen", "Ver.");
+					header.Alignment = Vector2(0.5F, 0.5F);
+					@header.Activated = spades::ui::EventHandler(this.SortServerListByProtocol);
+					serverPanel.AddChild(header);
+				}
+				{
+					ServerListHeader header(Manager);
+					header.Bounds = AABB2(contentsLeft + pingOffsetX, headerPos, contentsWidth - pingOffsetX, headerHeight);
+					header.Text = _Tr("MainScreen", "Ping");
+					header.Alignment = Vector2(0.5F, 0.5F);
+					@header.Activated = spades::ui::EventHandler(this.SortServerListByPing);
+					serverPanel.AddChild(header);
+				}
+				{
+					@loadingView = MainScreenServerListLoadingView(Manager);
+					loadingView.Bounds = AABB2(contentsLeft, listPos, contentsWidth, 100.0F);
+					loadingView.Visible = false;
+					serverPanel.AddChild(loadingView);
+				}
+				{
+					@errorView = MainScreenServerListErrorView(Manager);
+					errorView.Bounds = AABB2(contentsLeft, listPos, contentsWidth, 100.0F);
+					errorView.Visible = false;
+					serverPanel.AddChild(errorView);
+				}
+				// Server filter footer elements
+				{
+					spades::ui::Label label(Manager);
+					label.Text = _Tr("MainScreen", "Filter");
+					label.Bounds = AABB2(contentsLeft, footerPos, 50.0F, 30.0F);
+					label.Alignment = Vector2(0.0F, 0.5F);
+					serverPanel.AddChild(label);
+				}
+				{
+					@filterProtocol3Button = ProtocolButton(Manager);
+					filterProtocol3Button.Bounds = AABB2(contentsLeft + 50.0F, footerPos, 40.0F, 30.0F);
+					filterProtocol3Button.Caption = _Tr("MainScreen", "0.75");
+					@filterProtocol3Button.Activated = spades::ui::EventHandler(this.OnFilterProtocol3Pressed);
+					filterProtocol3Button.Toggle = true;
+					serverPanel.AddChild(filterProtocol3Button);
+				}
+				{
+					@filterProtocol4Button = ProtocolButton(Manager);
+					filterProtocol4Button.Bounds = AABB2(contentsLeft + 90.0F, footerPos, 40.0F, 30.0F);
+					filterProtocol4Button.Caption = _Tr("MainScreen", "0.76");
+					@filterProtocol4Button.Activated = spades::ui::EventHandler(this.OnFilterProtocol4Pressed);
+					filterProtocol4Button.Toggle = true;
+					serverPanel.AddChild(filterProtocol4Button);
+				}
+				{
+					@filterEmptyButton = ProtocolButton(Manager);
+					filterEmptyButton.Bounds = AABB2(contentsLeft + 135.0F, footerPos, 50.0F, 30.0F);
+					filterEmptyButton.Caption = _Tr("MainScreen", "Empty");
+					@filterEmptyButton.Activated = spades::ui::EventHandler(this.OnFilterEmptyPressed);
+					filterEmptyButton.Toggle = true;
+					serverPanel.AddChild(filterEmptyButton);
+				}
+				{
+					@filterFullButton = ProtocolButton(Manager);
+					filterFullButton.Bounds = AABB2(contentsLeft + 185.0F, footerPos, 70.0F, 30.0F);
+					filterFullButton.Caption = _Tr("MainScreen", "Not Full");
+					@filterFullButton.Activated = spades::ui::EventHandler(this.OnFilterFullPressed);
+					filterFullButton.Toggle = true;
+					serverPanel.AddChild(filterFullButton);
+				}
+				{
+					@filterField = spades::ui::Field(Manager);
+					filterField.Bounds = AABB2(contentsLeft + 260.0F, footerPos, contentsWidth - 567.0F, 30.0F);
+					filterField.Placeholder = _Tr("MainScreen", "Filter");
+					@filterField.Changed = spades::ui::EventHandler(this.OnFilterTextChanged);
+					serverPanel.AddChild(filterField);
+				}
+
+				// --- Demo panel contents ---
+				{
+					spades::ui::Button playButton(Manager);
+					playButton.Caption = _Tr("MainScreen", "Play");
+					playButton.Bounds = AABB2(contentsLeft + contentsWidth - 150.0F, 200.0F, 150.0F, 30.0F);
+					@playButton.Activated = spades::ui::EventHandler(this.OnPlayDemoPressed);
+					demoPanel.AddChild(playButton);
+				}
+				{
+					DemoListHeader header(Manager);
+					header.Bounds = AABB2(contentsLeft, headerPos, contentsWidth, headerHeight);
+					header.Text = _Tr("MainScreen", "Demo File");
+					demoPanel.AddChild(header);
+				}
+				{
+					@demoList = spades::ui::ListView(Manager);
+					demoList.Bounds = AABB2(contentsLeft, listPos, contentsWidth, footerPos - listPos - 14.0F);
+					demoPanel.AddChild(demoList);
+				}
+
+				AddChild(serverPanel);
+				AddChild(demoPanel);
+
+				// Tab strip
+				{
+					spades::ui::SimpleTabStrip tabStrip(Manager);
+					tabStrip.Bounds = AABB2(contentsLeft, tabStripPos, contentsWidth, 24.0F);
+					AddChild(tabStrip);
+					tabStrip.AddItem(_Tr("MainScreen", "Servers"), serverPanel);
+					tabStrip.AddItem(_Tr("MainScreen", "Demos"), demoPanel);
+					@tabStrip.Changed = spades::ui::EventHandler(this.OnTabChanged);
+				}
 			}
-			{
-				@addressField = spades::ui::Field(Manager);
-				addressField.Bounds = AABB2(contentsLeft, 200.0F, contentsWidth - 270.0F, 30.0F);
-				addressField.Placeholder = _Tr("MainScreen", "Quick Connect");
-				addressField.Text = cg_lastQuickConnectHost.StringValue;
-				@addressField.Changed = spades::ui::EventHandler(this.OnAddressChanged);
-				AddChild(addressField);
-			}
-			{
-				RefreshButton button(Manager);
-				button.Bounds = AABB2(contentsLeft + contentsWidth - 270.0F, 200.0F, 30.0F, 30.0F);
-				@button.Activated = spades::ui::EventHandler(this.OnRefreshServerListPressed);
-				AddChild(button);
-			}
-			{
-				@protocol3Button = ProtocolButton(Manager);
-				protocol3Button.Bounds = AABB2(contentsLeft + contentsWidth - 240.0F + 6.0F, 200.0F, 40.0F, 30.0F);
-				protocol3Button.Caption = _Tr("MainScreen", "0.75");
-				@protocol3Button.Activated = spades::ui::EventHandler(this.OnProtocol3Pressed);
-				protocol3Button.Toggle = true;
-				protocol3Button.Toggled = cg_protocolVersion.IntValue == 3;
-				AddChild(protocol3Button);
-			}
-			{
-				@protocol4Button = ProtocolButton(Manager);
-				protocol4Button.Bounds = AABB2(contentsLeft + contentsWidth - 200.0F + 6.0F, 200.0F, 40.0F, 30.0F);
-				protocol4Button.Caption = _Tr("MainScreen", "0.76");
-				@protocol4Button.Activated = spades::ui::EventHandler(this.OnProtocol4Pressed);
-				protocol4Button.Toggle = true;
-				protocol4Button.Toggled = cg_protocolVersion.IntValue == 4;
-				AddChild(protocol4Button);
-			}
+
+			// Footer buttons (always visible, outside panels)
 			{
 				spades::ui::Button button(Manager);
 				button.Caption = _Tr("MainScreen", "Quit");
@@ -173,118 +345,9 @@ namespace spades {
 				@button.Activated = spades::ui::EventHandler(this.OnSetupPressed);
 				AddChild(button);
 			}
-			{
-				spades::ui::Label label(Manager);
-				label.Text = _Tr("MainScreen", "Filter");
-				label.Bounds = AABB2(contentsLeft, footerPos, 50.0F, 30.0F);
-				label.Alignment = Vector2(0.0F, 0.5F);
-				AddChild(label);
-			}
-			{
-				@filterProtocol3Button = ProtocolButton(Manager);
-				filterProtocol3Button.Bounds = AABB2(contentsLeft + 50.0F, footerPos, 40.0F, 30.0F);
-				filterProtocol3Button.Caption = _Tr("MainScreen", "0.75");
-				@filterProtocol3Button.Activated = spades::ui::EventHandler(this.OnFilterProtocol3Pressed);
-				filterProtocol3Button.Toggle = true;
-				AddChild(filterProtocol3Button);
-			}
-			{
-				@filterProtocol4Button = ProtocolButton(Manager);
-				filterProtocol4Button.Bounds = AABB2(contentsLeft + 90.0F, footerPos, 40.0F, 30.0F);
-				filterProtocol4Button.Caption = _Tr("MainScreen", "0.76");
-				@filterProtocol4Button.Activated = spades::ui::EventHandler(this.OnFilterProtocol4Pressed);
-				filterProtocol4Button.Toggle = true;
-				AddChild(filterProtocol4Button);
-			}
-			{
-				@filterEmptyButton = ProtocolButton(Manager);
-				filterEmptyButton.Bounds = AABB2(contentsLeft + 135.0F, footerPos, 50.0F, 30.0F);
-				filterEmptyButton.Caption = _Tr("MainScreen", "Empty");
-				@filterEmptyButton.Activated = spades::ui::EventHandler(this.OnFilterEmptyPressed);
-				filterEmptyButton.Toggle = true;
-				AddChild(filterEmptyButton);
-			}
-			{
-				@filterFullButton = ProtocolButton(Manager);
-				filterFullButton.Bounds = AABB2(contentsLeft + 185.0F, footerPos, 70.0F, 30.0F);
-				filterFullButton.Caption = _Tr("MainScreen", "Not Full");
-				@filterFullButton.Activated = spades::ui::EventHandler(this.OnFilterFullPressed);
-				filterFullButton.Toggle = true;
-				AddChild(filterFullButton);
-			}
-			{
-				@filterField = spades::ui::Field(Manager);
-				filterField.Bounds = AABB2(contentsLeft + 260.0F, footerPos, contentsWidth - 567.0F, 30.0F);
-				filterField.Placeholder = _Tr("MainScreen", "Filter");
-				@filterField.Changed = spades::ui::EventHandler(this.OnFilterTextChanged);
-				AddChild(filterField);
-			}
-			{
-				@serverList = spades::ui::ListView(Manager);
-				serverList.Bounds = AABB2(contentsLeft, 270.0F, contentsWidth, footerPos - 284.0F);
-				AddChild(serverList);
-			}
-
-			{
-				ServerListHeader header(Manager);
-				header.Bounds = AABB2(contentsLeft, headerPos, slotsOffsetX, headerHeight);
-				header.Text = _Tr("MainScreen", "Server Name");
-				@header.Activated = spades::ui::EventHandler(this.SortServerListByName);
-				AddChild(header);
-			}
-			{
-				ServerListHeader header(Manager);
-				header.Bounds = AABB2(contentsLeft + slotsOffsetX, headerPos, mapNameOffsetX - slotsOffsetX, headerHeight);
-				header.Text = _Tr("MainScreen", "Slots");
-				header.Alignment = Vector2(0.5F, 0.5F);
-				@header.Activated = spades::ui::EventHandler(this.SortServerListByNumPlayers);
-				AddChild(header);
-			}
-			{
-				ServerListHeader header(Manager);
-				header.Bounds = AABB2(contentsLeft + mapNameOffsetX, headerPos, gameModeOffsetX - mapNameOffsetX, headerHeight);
-				header.Text = _Tr("MainScreen", "Map Name");
-				@header.Activated = spades::ui::EventHandler(this.SortServerListByMapName);
-				AddChild(header);
-			}
-			{
-				ServerListHeader header(Manager);
-				header.Bounds = AABB2(contentsLeft + gameModeOffsetX, headerPos, protocolOffsetX - gameModeOffsetX, headerHeight);
-				header.Text = _Tr("MainScreen", "Game Mode");
-				header.Alignment = Vector2(0.5F, 0.5F);
-				@header.Activated = spades::ui::EventHandler(this.SortServerListByGameMode);
-				AddChild(header);
-			}
-			{
-				ServerListHeader header(Manager);
-				header.Bounds = AABB2(contentsLeft + protocolOffsetX, headerPos, pingOffsetX - protocolOffsetX, headerHeight);
-				header.Text = _Tr("MainScreen", "Ver.");
-				header.Alignment = Vector2(0.5F, 0.5F);
-				@header.Activated = spades::ui::EventHandler(this.SortServerListByProtocol);
-				AddChild(header);
-			}
-			{
-				ServerListHeader header(Manager);
-				header.Bounds = AABB2(contentsLeft + pingOffsetX, headerPos, contentsWidth - pingOffsetX, headerHeight);
-				header.Text = _Tr("MainScreen", "Ping");
-				header.Alignment = Vector2(0.5F, 0.5F);
-				@header.Activated = spades::ui::EventHandler(this.SortServerListByPing);
-				AddChild(header);
-			}
-			{
-				@loadingView = MainScreenServerListLoadingView(Manager);
-				loadingView.Bounds = AABB2(contentsLeft, 240.0F, contentsWidth, 100.0F);
-				loadingView.Visible = false;
-				AddChild(loadingView);
-			}
-			{
-				@errorView = MainScreenServerListErrorView(Manager);
-				errorView.Bounds = AABB2(contentsLeft, 240.0F, contentsWidth, 100.0F);
-				errorView.Visible = false;
-				AddChild(errorView);
-			}
 
 			LoadServerList();
+			LoadDemoList();
 		}
 
 		void LoadServerList() {
@@ -296,6 +359,52 @@ namespace spades {
 			errorView.Visible = false;
 			loadingView.Visible = true;
 			helper.StartQuery();
+		}
+
+		void LoadDemoList() {
+			string[]@ demos = helper.GetDemoList();
+			if (demos is null) {
+				@demoList.Model = spades::ui::ListViewModel();
+				return;
+			}
+			// Reverse so newest demos appear first
+			string[] reversed;
+			for (int i = int(demos.length) - 1; i >= 0; i--)
+				reversed.insertLast(demos[i]);
+			DemoListModel model(Manager, reversed);
+			@demoList.Model = model;
+			@model.ItemActivated = DemoListItemEventHandler(this.DemoListItemActivated);
+			@model.ItemDoubleClicked = DemoListItemEventHandler(this.DemoListItemDoubleClicked);
+			@currentDemoListModel = model;
+		}
+
+		private void OnTabChanged(spades::ui::UIElement@ sender) {
+			// Refresh demo list when switching to demos tab
+			if (demoPanel.Visible)
+				LoadDemoList();
+		}
+
+		void DemoListItemActivated(DemoListModel@ sender, string filename) {
+			selectedDemoPath = filename;
+		}
+
+		void DemoListItemDoubleClicked(DemoListModel@ sender, string filename) {
+			selectedDemoPath = filename;
+			PlaySelectedDemo();
+		}
+
+		private void PlaySelectedDemo() {
+			if (selectedDemoPath.length == 0)
+				return;
+			string msg = helper.PlayDemo(selectedDemoPath);
+			if (msg.length > 0) {
+				AlertScreen al(this, msg);
+				al.Run();
+			}
+		}
+
+		private void OnPlayDemoPressed(spades::ui::UIElement@ sender) {
+			PlaySelectedDemo();
 		}
 
 		void ServerListItemActivated(ServerListModel@ sender, MainScreenServerItem@ item) {
@@ -494,7 +603,11 @@ namespace spades {
 
 		void HotKey(string key) {
 			if (IsEnabled and key == "Enter") {
-				Connect();
+				if (demoPanel.Visible) {
+					PlaySelectedDemo();
+				} else {
+					Connect();
+				}
 			} else if (IsEnabled and key == "Escape") {
 				ui.shouldExit = true;
 			} else {

--- a/Resources/Scripts/Gui/MainScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/MainScreen/MainMenu.as
@@ -79,6 +79,7 @@ namespace spades {
 
 		ServerListModel@ currentServerListModel;
 		int serverListUpdateTimer = 5;
+		string selectedMapName;
 
 		private ConfigItem cg_protocolVersion("cg_protocolVersion", "3");
 		private ConfigItem cg_lastQuickConnectHost("cg_lastQuickConnectHost", "127.0.0.1");
@@ -300,6 +301,7 @@ namespace spades {
 		void ServerListItemActivated(ServerListModel@ sender, MainScreenServerItem@ item) {
 			addressField.Text = item.Address;
 			cg_lastQuickConnectHost = addressField.Text;
+			selectedMapName = item.MapName;
 			if (item.Protocol == "0.75") {
 				SetProtocolVersion(3);
 			} else if (item.Protocol == "0.76") {
@@ -435,6 +437,7 @@ namespace spades {
 
 		private void OnAddressChanged(spades::ui::UIElement@ sender) {
 			cg_lastQuickConnectHost = addressField.Text;
+			selectedMapName = "";
 		}
 
 		private void SetProtocolVersion(int ver) {
@@ -479,7 +482,7 @@ namespace spades {
 		}
 
 		private void Connect() {
-			string msg = helper.ConnectServer(addressField.Text, cg_protocolVersion.IntValue);
+			string msg = helper.ConnectServer(addressField.Text, cg_protocolVersion.IntValue, selectedMapName);
 			if (msg.length > 0) {
 				// failde to initialize client.
 				AlertScreen al(this, msg);

--- a/Resources/Scripts/Gui/MainScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/MainScreen/MainMenu.as
@@ -93,6 +93,9 @@ namespace spades {
 		spades::ui::ListView@ demoList;
 		DemoListModel@ currentDemoListModel;
 		string selectedDemoPath;
+		spades::ui::Field@ demoNameField;
+		spades::ui::Button@ demoPlayButton;
+		spades::ui::Button@ demoDeleteButton;
 
 		// Demo list column widths (pixels)
 		private float demoDateColWidth;
@@ -301,11 +304,28 @@ namespace spades {
 
 				// --- Demo panel contents ---
 				{
-					spades::ui::Button playButton(Manager);
-					playButton.Caption = _Tr("MainScreen", "Play");
-					playButton.Bounds = AABB2(contentsLeft + contentsWidth - 150.0F, 200.0F, 150.0F, 30.0F);
-					@playButton.Activated = spades::ui::EventHandler(this.OnPlayDemoPressed);
-					demoPanel.AddChild(playButton);
+					// Selected demo name display (mirrors the server address field)
+					@demoNameField = spades::ui::Field(Manager);
+					demoNameField.Bounds = AABB2(contentsLeft, 200.0F, contentsWidth - 270.0F, 30.0F);
+					demoNameField.Placeholder = _Tr("MainScreen", "Select a demo");
+					demoNameField.AcceptsFocus = false;
+					demoNameField.IsMouseInteractive = false;
+					demoPanel.AddChild(demoNameField);
+				}
+				{
+					@demoDeleteButton = spades::ui::Button(Manager);
+					demoDeleteButton.Caption = _Tr("MainScreen", "Delete");
+					demoDeleteButton.Bounds = AABB2(contentsLeft + contentsWidth - 270.0F, 200.0F, 110.0F, 30.0F);
+					@demoDeleteButton.Activated = spades::ui::EventHandler(this.OnDeleteDemoPressed);
+					demoPanel.AddChild(demoDeleteButton);
+				}
+				{
+					@demoPlayButton = spades::ui::Button(Manager);
+					demoPlayButton.Caption = _Tr("MainScreen", "Play");
+					demoPlayButton.HotKeyText = _Tr("Client", "[Enter]");
+					demoPlayButton.Bounds = AABB2(contentsLeft + contentsWidth - 150.0F, 200.0F, 150.0F, 30.0F);
+					@demoPlayButton.Activated = spades::ui::EventHandler(this.OnPlayDemoPressed);
+					demoPanel.AddChild(demoPlayButton);
 				}
 				{
 					// Column order: Server | Map | Mode | Timestamp | Size
@@ -432,10 +452,12 @@ namespace spades {
 
 		void DemoListItemActivated(DemoListModel@ sender, string filename) {
 			selectedDemoPath = filename;
+			demoNameField.Text = StripDemoPath(filename);
 		}
 
 		void DemoListItemDoubleClicked(DemoListModel@ sender, string filename) {
 			selectedDemoPath = filename;
+			demoNameField.Text = StripDemoPath(filename);
 			PlaySelectedDemo();
 		}
 
@@ -451,6 +473,16 @@ namespace spades {
 
 		private void OnPlayDemoPressed(spades::ui::UIElement@ sender) {
 			PlaySelectedDemo();
+		}
+
+		private void OnDeleteDemoPressed(spades::ui::UIElement@ sender) {
+			if (selectedDemoPath.length == 0)
+				return;
+			if (!helper.DeleteDemo(selectedDemoPath))
+				return;
+			selectedDemoPath = "";
+			demoNameField.Text = "";
+			LoadDemoList();
 		}
 
 		void ServerListItemActivated(ServerListModel@ sender, MainScreenServerItem@ item) {

--- a/Resources/Scripts/Gui/MainScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/MainScreen/MainMenu.as
@@ -94,6 +94,11 @@ namespace spades {
 		DemoListModel@ currentDemoListModel;
 		string selectedDemoPath;
 
+		// Demo list column widths (pixels)
+		private float demoDateColWidth;
+		private float demoModeColWidth;
+		private float demoMapColWidth;
+
 		private ConfigItem cg_protocolVersion("cg_protocolVersion", "3");
 		private ConfigItem cg_lastQuickConnectHost("cg_lastQuickConnectHost", "127.0.0.1");
 		private ConfigItem cg_serverlistSort("cg_serverlistSort", "16385");
@@ -103,6 +108,10 @@ namespace spades {
 			@this.ui = ui;
 			@this.helper = ui.helper;
 			@this.Font = ui.fontManager.GuiFont;
+
+			demoDateColWidth = 130.0F;
+			demoModeColWidth = 65.0F;
+			demoMapColWidth  = 185.0F;
 
 			float sw = Manager.ScreenWidth;
 			float sh = Manager.ScreenHeight;
@@ -297,10 +306,33 @@ namespace spades {
 					demoPanel.AddChild(playButton);
 				}
 				{
-					DemoListHeader header(Manager);
-					header.Bounds = AABB2(contentsLeft, headerPos, contentsWidth, headerHeight);
-					header.Text = _Tr("MainScreen", "Demo File");
-					demoPanel.AddChild(header);
+					// Column order: Server | Map | Mode | Date
+					// Server is variable-width; the three rightmost columns are fixed.
+					float serverColWidth = contentsWidth - demoMapColWidth - demoModeColWidth - demoDateColWidth;
+					{
+						DemoListHeader header(Manager);
+						header.Bounds = AABB2(contentsLeft, headerPos, serverColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Server");
+						demoPanel.AddChild(header);
+					}
+					{
+						DemoListHeader header(Manager);
+						header.Bounds = AABB2(contentsLeft + serverColWidth, headerPos, demoMapColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Map");
+						demoPanel.AddChild(header);
+					}
+					{
+						DemoListHeader header(Manager);
+						header.Bounds = AABB2(contentsLeft + serverColWidth + demoMapColWidth, headerPos, demoModeColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Mode");
+						demoPanel.AddChild(header);
+					}
+					{
+						DemoListHeader header(Manager);
+						header.Bounds = AABB2(contentsLeft + serverColWidth + demoMapColWidth + demoModeColWidth, headerPos, demoDateColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Date");
+						demoPanel.AddChild(header);
+					}
 				}
 				{
 					@demoList = spades::ui::ListView(Manager);
@@ -371,7 +403,7 @@ namespace spades {
 			string[] reversed;
 			for (int i = int(demos.length) - 1; i >= 0; i--)
 				reversed.insertLast(demos[i]);
-			DemoListModel model(Manager, reversed);
+			DemoListModel model(Manager, reversed, demoDateColWidth, demoModeColWidth, demoMapColWidth);
 			@demoList.Model = model;
 			@model.ItemActivated = DemoListItemEventHandler(this.DemoListItemActivated);
 			@model.ItemDoubleClicked = DemoListItemEventHandler(this.DemoListItemDoubleClicked);

--- a/Resources/Scripts/Gui/MainScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/MainScreen/MainMenu.as
@@ -669,9 +669,10 @@ namespace spades {
 		}
 
 		private void Connect() {
+			// Pass selectedMapName if known (server clicked in list); otherwise pass empty
+			// and let ConnectServer resolve it from the cached server list on the C++ side.
 			string msg = helper.ConnectServer(addressField.Text, cg_protocolVersion.IntValue, selectedMapName);
 			if (msg.length > 0) {
-				// failde to initialize client.
 				AlertScreen al(this, msg);
 				al.Run();
 			}

--- a/Resources/Scripts/Gui/MainScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/MainScreen/MainMenu.as
@@ -102,6 +102,7 @@ namespace spades {
 		private float demoModeColWidth;
 		private float demoMapColWidth;
 		private float demoSizeColWidth;
+		private float demoContentsWidth;
 
 		private ConfigItem cg_protocolVersion("cg_protocolVersion", "3");
 		private ConfigItem cg_lastQuickConnectHost("cg_lastQuickConnectHost", "127.0.0.1");
@@ -114,7 +115,7 @@ namespace spades {
 			@this.Font = ui.fontManager.GuiFont;
 
 			demoDateColWidth = 130.0F;
-			demoModeColWidth = 65.0F;
+			demoModeColWidth = 85.0F;
 			demoMapColWidth  = 185.0F;
 			demoSizeColWidth = 70.0F;
 
@@ -125,6 +126,7 @@ namespace spades {
 			float maxContentsWidth = 750.0F;
 			if (contentsWidth > maxContentsWidth)
 				contentsWidth = maxContentsWidth;
+			demoContentsWidth = contentsWidth;
 
 			float contentsLeft = (sw - contentsWidth) * 0.5F;
 			float footerPos = sh - 50.0F;
@@ -350,7 +352,7 @@ namespace spades {
 					{
 						DemoListHeader header(Manager);
 						header.Bounds = AABB2(x, headerPos, demoModeColWidth, headerHeight);
-						header.Text = _Tr("MainScreen", "Mode");
+						header.Text = _Tr("MainScreen", "Game Mode");
 						demoPanel.AddChild(header);
 						x += demoModeColWidth;
 					}
@@ -437,7 +439,7 @@ namespace spades {
 			string[] reversed;
 			for (int i = int(demos.length) - 1; i >= 0; i--)
 				reversed.insertLast(demos[i]);
-			DemoListModel model(Manager, helper, reversed, demoDateColWidth, demoModeColWidth, demoMapColWidth, demoSizeColWidth);
+			DemoListModel model(Manager, helper, reversed, demoDateColWidth, demoModeColWidth, demoMapColWidth, demoSizeColWidth, demoContentsWidth);
 			@demoList.Model = model;
 			@model.ItemActivated = DemoListItemEventHandler(this.DemoListItemActivated);
 			@model.ItemDoubleClicked = DemoListItemEventHandler(this.DemoListItemDoubleClicked);

--- a/Resources/Scripts/Gui/Preferences.as
+++ b/Resources/Scripts/Gui/Preferences.as
@@ -1868,6 +1868,7 @@ namespace spades {
 			layouter.AddControl(_Tr("Preferences", "Master Volume Up"), "cg_keyVolumeUp");
 			layouter.AddControl(_Tr("Preferences", "Master Volume Down"), "cg_keyVolumeDown");
 			layouter.AddControl(_Tr("Preferences", "Force Spectator Mode"), "cg_keyStaffSpectating");
+			layouter.AddControl(_Tr("Preferences", "Toggle Demo Recording"), "cg_keyDemoRecord");
 
 			layouter.FinishLayout();
 		}

--- a/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
+++ b/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
@@ -735,9 +735,9 @@ namespace spades {
 		private spades::ui::CheckBox@ buttonAutoRecord;
 		private spades::ui::CheckBox@ buttonAutoPrune;
 		private spades::ui::Field@ fieldMaxDemos;
-		private ConfigItem cg_autoRecord("cg_autoRecord");
-		private ConfigItem cg_autoPruneDemos("cg_autoPruneDemos");
-		private ConfigItem cg_maxDemos("cg_maxDemos");
+		private ConfigItem cg_demoAutoRecord("cg_demoAutoRecord");
+		private ConfigItem cg_demoAutoPrune("cg_demoAutoPrune");
+		private ConfigItem cg_demoMaxFiles("cg_demoMaxFiles");
 
 		StartupScreenRecordingTab(StartupScreenUI@ ui, Vector2 size) {
 			super(ui.manager);
@@ -792,23 +792,23 @@ namespace spades {
 		}
 
 		void LoadConfig() {
-			buttonAutoRecord.Toggled = cg_autoRecord.IntValue != 0;
-			buttonAutoPrune.Toggled = cg_autoPruneDemos.IntValue != 0;
-			fieldMaxDemos.Text = cg_maxDemos.StringValue;
+			buttonAutoRecord.Toggled = cg_demoAutoRecord.IntValue != 0;
+			buttonAutoPrune.Toggled = cg_demoAutoPrune.IntValue != 0;
+			fieldMaxDemos.Text = cg_demoMaxFiles.StringValue;
 		}
 
 		private void OnAutoRecordChanged(spades::ui::UIElement@) {
-			cg_autoRecord.IntValue = buttonAutoRecord.Toggled ? 1 : 0;
+			cg_demoAutoRecord.IntValue = buttonAutoRecord.Toggled ? 1 : 0;
 		}
 
 		private void OnAutoPruneChanged(spades::ui::UIElement@) {
-			cg_autoPruneDemos.IntValue = buttonAutoPrune.Toggled ? 1 : 0;
+			cg_demoAutoPrune.IntValue = buttonAutoPrune.Toggled ? 1 : 0;
 		}
 
 		private void OnMaxDemosChanged(spades::ui::UIElement@) {
 			int v = ParseInt(fieldMaxDemos.Text);
 			if (v >= 1)
-				cg_maxDemos.IntValue = v;
+				cg_demoMaxFiles.IntValue = v;
 		}
 
 		private void OnBrowseDemosFolderPressed(spades::ui::UIElement@) {

--- a/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
+++ b/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
@@ -633,10 +633,6 @@ namespace spades {
 		StartupScreenUI@ ui;
 		StartupScreenHelper@ helper;
 		StartupScreenLocaleEditor@ editLocale;
-		private spades::ui::CheckBox@ buttonAutoRecord;
-		private spades::ui::Field@ fieldMaxDemos;
-		private ConfigItem cg_autoRecord("cg_autoRecord");
-		private ConfigItem cg_maxDemos("cg_maxDemos");
 
 		StartupScreenGenericTab(StartupScreenUI@ ui, Vector2 size) {
 			super(ui.manager);
@@ -677,41 +673,10 @@ namespace spades {
 				@button.Activated = spades::ui::EventHandler(this.OnBrowseUserDirectoryPressed);
 				AddChild(button);
 			}
-
-			AddLabel(0.0F, 108.0F, 24.0F, _Tr("StartupScreen", "Demo Recording"));
-			{
-				spades::ui::CheckBox chk(Manager);
-				chk.Caption = _Tr("StartupScreen", "Automatically record every game");
-				chk.Bounds = AABB2(160.0F, 108.0F, 350.0F, 24.0F);
-				@chk.Activated = spades::ui::EventHandler(this.OnAutoRecordChanged);
-				AddChild(chk);
-				@buttonAutoRecord = chk;
-			}
-			AddLabel(0.0F, 138.0F, 24.0F, _Tr("StartupScreen", "Max stored demos"));
-			{
-				spades::ui::Field fld(Manager);
-				fld.Bounds = AABB2(160.0F, 138.0F, 80.0F, 24.0F);
-				fld.DenyNonAscii = true;
-				@fld.Changed = spades::ui::EventHandler(this.OnMaxDemosChanged);
-				AddChild(fld);
-				@fieldMaxDemos = fld;
-			}
 		}
 
 		void LoadConfig() {
 			editLocale.LoadConfig();
-			buttonAutoRecord.Toggled = cg_autoRecord.IntValue != 0;
-			fieldMaxDemos.Text = cg_maxDemos.StringValue;
-		}
-
-		private void OnAutoRecordChanged(spades::ui::UIElement@) {
-			cg_autoRecord.IntValue = buttonAutoRecord.Toggled ? 1 : 0;
-		}
-
-		private void OnMaxDemosChanged(spades::ui::UIElement@) {
-			int v = ParseInt(fieldMaxDemos.Text);
-			if (v >= 1)
-				cg_maxDemos.IntValue = v;
 		}
 
 		private void OnBrowseUserDirectoryPressed(spades::ui::UIElement@) {
@@ -761,6 +726,99 @@ namespace spades {
 
 			// Some of default values may be infeasible for the user's system.
 			helper.FixConfigs();
+		}
+	}
+
+	class StartupScreenRecordingTab : spades::ui::UIElement, LabelAddable {
+		StartupScreenUI@ ui;
+		StartupScreenHelper@ helper;
+		private spades::ui::CheckBox@ buttonAutoRecord;
+		private spades::ui::CheckBox@ buttonAutoPrune;
+		private spades::ui::Field@ fieldMaxDemos;
+		private ConfigItem cg_autoRecord("cg_autoRecord");
+		private ConfigItem cg_autoPruneDemos("cg_autoPruneDemos");
+		private ConfigItem cg_maxDemos("cg_maxDemos");
+
+		StartupScreenRecordingTab(StartupScreenUI@ ui, Vector2 size) {
+			super(ui.manager);
+			@this.ui = ui;
+			@helper = ui.helper;
+
+			AddLabel(0.0F, 0.0F, 24.0F, _Tr("StartupScreen", "Demo Recording"));
+			{
+				spades::ui::CheckBox chk(Manager);
+				chk.Caption = _Tr("StartupScreen", "Automatically record every game");
+				chk.Bounds = AABB2(160.0F, 0.0F, 350.0F, 24.0F);
+				@chk.Activated = spades::ui::EventHandler(this.OnAutoRecordChanged);
+				AddChild(chk);
+				@buttonAutoRecord = chk;
+			}
+
+			AddLabel(0.0F, 30.0F, 24.0F, _Tr("StartupScreen", "Auto-delete old demos"));
+			{
+				spades::ui::CheckBox chk(Manager);
+				chk.Caption = _Tr("StartupScreen", "Delete oldest demos when limit is reached");
+				chk.Bounds = AABB2(160.0F, 30.0F, 350.0F, 24.0F);
+				@chk.Activated = spades::ui::EventHandler(this.OnAutoPruneChanged);
+				AddChild(chk);
+				@buttonAutoPrune = chk;
+			}
+
+			AddLabel(0.0F, 60.0F, 24.0F, _Tr("StartupScreen", "Max stored demos"));
+			{
+				spades::ui::Field fld(Manager);
+				fld.Bounds = AABB2(160.0F, 60.0F, 80.0F, 24.0F);
+				fld.DenyNonAscii = true;
+				@fld.Changed = spades::ui::EventHandler(this.OnMaxDemosChanged);
+				AddChild(fld);
+				@fieldMaxDemos = fld;
+			}
+
+			AddLabel(0.0F, 96.0F, 30.0F, _Tr("StartupScreen", "Demos Folder"));
+			{
+				spades::ui::Button button(Manager);
+				string osType = helper.OperatingSystemType;
+				if (osType == "Windows") {
+					button.Caption = _Tr("StartupScreen", "Open Demos Folder in Explorer");
+				} else if (osType == "Mac") {
+					button.Caption = _Tr("StartupScreen", "Reveal Demos Folder in Finder");
+				} else {
+					button.Caption = _Tr("StartupScreen", "Browse Demos Folder");
+				}
+				button.Bounds = AABB2(160.0F, 96.0F, 350.0F, 30.0F);
+				@button.Activated = spades::ui::EventHandler(this.OnBrowseDemosFolderPressed);
+				AddChild(button);
+			}
+		}
+
+		void LoadConfig() {
+			buttonAutoRecord.Toggled = cg_autoRecord.IntValue != 0;
+			buttonAutoPrune.Toggled = cg_autoPruneDemos.IntValue != 0;
+			fieldMaxDemos.Text = cg_maxDemos.StringValue;
+		}
+
+		private void OnAutoRecordChanged(spades::ui::UIElement@) {
+			cg_autoRecord.IntValue = buttonAutoRecord.Toggled ? 1 : 0;
+		}
+
+		private void OnAutoPruneChanged(spades::ui::UIElement@) {
+			cg_autoPruneDemos.IntValue = buttonAutoPrune.Toggled ? 1 : 0;
+		}
+
+		private void OnMaxDemosChanged(spades::ui::UIElement@) {
+			int v = ParseInt(fieldMaxDemos.Text);
+			if (v >= 1)
+				cg_maxDemos.IntValue = v;
+		}
+
+		private void OnBrowseDemosFolderPressed(spades::ui::UIElement@) {
+			if (helper.BrowseDemosDirectory())
+				return;
+
+			string msg = _Tr("StartupScreen",
+							 "An unknown error has occurred while opening the demos directory.");
+			AlertScreen al(Parent, msg, 100.0F);
+			al.Run();
 		}
 	}
 

--- a/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
+++ b/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
@@ -634,7 +634,9 @@ namespace spades {
 		StartupScreenHelper@ helper;
 		StartupScreenLocaleEditor@ editLocale;
 		private spades::ui::CheckBox@ buttonAutoRecord;
+		private spades::ui::Field@ fieldMaxDemos;
 		private ConfigItem cg_autoRecord("cg_autoRecord");
+		private ConfigItem cg_maxDemos("cg_maxDemos");
 
 		StartupScreenGenericTab(StartupScreenUI@ ui, Vector2 size) {
 			super(ui.manager);
@@ -685,15 +687,31 @@ namespace spades {
 				AddChild(chk);
 				@buttonAutoRecord = chk;
 			}
+			AddLabel(0.0F, 138.0F, 24.0F, _Tr("StartupScreen", "Max stored demos"));
+			{
+				spades::ui::Field fld(Manager);
+				fld.Bounds = AABB2(160.0F, 138.0F, 80.0F, 24.0F);
+				fld.DenyNonAscii = true;
+				@fld.Changed = spades::ui::EventHandler(this.OnMaxDemosChanged);
+				AddChild(fld);
+				@fieldMaxDemos = fld;
+			}
 		}
 
 		void LoadConfig() {
 			editLocale.LoadConfig();
 			buttonAutoRecord.Toggled = cg_autoRecord.IntValue != 0;
+			fieldMaxDemos.Text = cg_maxDemos.StringValue;
 		}
 
 		private void OnAutoRecordChanged(spades::ui::UIElement@) {
 			cg_autoRecord.IntValue = buttonAutoRecord.Toggled ? 1 : 0;
+		}
+
+		private void OnMaxDemosChanged(spades::ui::UIElement@) {
+			int v = ParseInt(fieldMaxDemos.Text);
+			if (v >= 1)
+				cg_maxDemos.IntValue = v;
 		}
 
 		private void OnBrowseUserDirectoryPressed(spades::ui::UIElement@) {

--- a/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
+++ b/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
@@ -633,6 +633,12 @@ namespace spades {
 		StartupScreenUI@ ui;
 		StartupScreenHelper@ helper;
 		StartupScreenLocaleEditor@ editLocale;
+		private spades::ui::CheckBox@ buttonAutoRecord;
+		private spades::ui::CheckBox@ buttonAutoPrune;
+		private spades::ui::Field@ fieldMaxDemos;
+		private ConfigItem cg_demoAutoRecord("cg_demoAutoRecord");
+		private ConfigItem cg_demoAutoPrune("cg_demoAutoPrune");
+		private ConfigItem cg_demoMaxFiles("cg_demoMaxFiles");
 
 		StartupScreenGenericTab(StartupScreenUI@ ui, Vector2 size) {
 			super(ui.manager);
@@ -673,10 +679,83 @@ namespace spades {
 				@button.Activated = spades::ui::EventHandler(this.OnBrowseUserDirectoryPressed);
 				AddChild(button);
 			}
+
+			AddLabel(0.0F, 108.0F, 24.0F, _Tr("StartupScreen", "Demo Recording"));
+			{
+				spades::ui::CheckBox chk(Manager);
+				chk.Caption = _Tr("StartupScreen", "Automatically record every game");
+				chk.Bounds = AABB2(160.0F, 108.0F, 350.0F, 24.0F);
+				@chk.Activated = spades::ui::EventHandler(this.OnAutoRecordChanged);
+				AddChild(chk);
+				@buttonAutoRecord = chk;
+			}
+
+			AddLabel(0.0F, 138.0F, 24.0F, _Tr("StartupScreen", "Auto-delete old demos"));
+			{
+				spades::ui::CheckBox chk(Manager);
+				chk.Caption = _Tr("StartupScreen", "Delete oldest demos when limit is reached");
+				chk.Bounds = AABB2(160.0F, 138.0F, 350.0F, 24.0F);
+				@chk.Activated = spades::ui::EventHandler(this.OnAutoPruneChanged);
+				AddChild(chk);
+				@buttonAutoPrune = chk;
+			}
+
+			AddLabel(0.0F, 168.0F, 24.0F, _Tr("StartupScreen", "Max stored demos"));
+			{
+				spades::ui::Field fld(Manager);
+				fld.Bounds = AABB2(160.0F, 168.0F, 80.0F, 24.0F);
+				fld.DenyNonAscii = true;
+				@fld.Changed = spades::ui::EventHandler(this.OnMaxDemosChanged);
+				AddChild(fld);
+				@fieldMaxDemos = fld;
+			}
+
+			AddLabel(0.0F, 204.0F, 30.0F, _Tr("StartupScreen", "Demos Folder"));
+			{
+				spades::ui::Button button(Manager);
+				string osType = helper.OperatingSystemType;
+				if (osType == "Windows") {
+					button.Caption = _Tr("StartupScreen", "Open Demos Folder in Explorer");
+				} else if (osType == "Mac") {
+					button.Caption = _Tr("StartupScreen", "Reveal Demos Folder in Finder");
+				} else {
+					button.Caption = _Tr("StartupScreen", "Browse Demos Folder");
+				}
+				button.Bounds = AABB2(160.0F, 204.0F, 350.0F, 30.0F);
+				@button.Activated = spades::ui::EventHandler(this.OnBrowseDemosFolderPressed);
+				AddChild(button);
+			}
 		}
 
 		void LoadConfig() {
 			editLocale.LoadConfig();
+			buttonAutoRecord.Toggled = cg_demoAutoRecord.IntValue != 0;
+			buttonAutoPrune.Toggled = cg_demoAutoPrune.IntValue != 0;
+			fieldMaxDemos.Text = cg_demoMaxFiles.StringValue;
+		}
+
+		private void OnAutoRecordChanged(spades::ui::UIElement@) {
+			cg_demoAutoRecord.IntValue = buttonAutoRecord.Toggled ? 1 : 0;
+		}
+
+		private void OnAutoPruneChanged(spades::ui::UIElement@) {
+			cg_demoAutoPrune.IntValue = buttonAutoPrune.Toggled ? 1 : 0;
+		}
+
+		private void OnMaxDemosChanged(spades::ui::UIElement@) {
+			int v = ParseInt(fieldMaxDemos.Text);
+			if (v >= 1)
+				cg_demoMaxFiles.IntValue = v;
+		}
+
+		private void OnBrowseDemosFolderPressed(spades::ui::UIElement@) {
+			if (helper.BrowseDemosDirectory())
+				return;
+
+			string msg = _Tr("StartupScreen",
+							 "An unknown error has occurred while opening the demos directory.");
+			AlertScreen al(Parent, msg, 100.0F);
+			al.Run();
 		}
 
 		private void OnBrowseUserDirectoryPressed(spades::ui::UIElement@) {
@@ -726,99 +805,6 @@ namespace spades {
 
 			// Some of default values may be infeasible for the user's system.
 			helper.FixConfigs();
-		}
-	}
-
-	class StartupScreenRecordingTab : spades::ui::UIElement, LabelAddable {
-		StartupScreenUI@ ui;
-		StartupScreenHelper@ helper;
-		private spades::ui::CheckBox@ buttonAutoRecord;
-		private spades::ui::CheckBox@ buttonAutoPrune;
-		private spades::ui::Field@ fieldMaxDemos;
-		private ConfigItem cg_demoAutoRecord("cg_demoAutoRecord");
-		private ConfigItem cg_demoAutoPrune("cg_demoAutoPrune");
-		private ConfigItem cg_demoMaxFiles("cg_demoMaxFiles");
-
-		StartupScreenRecordingTab(StartupScreenUI@ ui, Vector2 size) {
-			super(ui.manager);
-			@this.ui = ui;
-			@helper = ui.helper;
-
-			AddLabel(0.0F, 0.0F, 24.0F, _Tr("StartupScreen", "Demo Recording"));
-			{
-				spades::ui::CheckBox chk(Manager);
-				chk.Caption = _Tr("StartupScreen", "Automatically record every game");
-				chk.Bounds = AABB2(160.0F, 0.0F, 350.0F, 24.0F);
-				@chk.Activated = spades::ui::EventHandler(this.OnAutoRecordChanged);
-				AddChild(chk);
-				@buttonAutoRecord = chk;
-			}
-
-			AddLabel(0.0F, 30.0F, 24.0F, _Tr("StartupScreen", "Auto-delete old demos"));
-			{
-				spades::ui::CheckBox chk(Manager);
-				chk.Caption = _Tr("StartupScreen", "Delete oldest demos when limit is reached");
-				chk.Bounds = AABB2(160.0F, 30.0F, 350.0F, 24.0F);
-				@chk.Activated = spades::ui::EventHandler(this.OnAutoPruneChanged);
-				AddChild(chk);
-				@buttonAutoPrune = chk;
-			}
-
-			AddLabel(0.0F, 60.0F, 24.0F, _Tr("StartupScreen", "Max stored demos"));
-			{
-				spades::ui::Field fld(Manager);
-				fld.Bounds = AABB2(160.0F, 60.0F, 80.0F, 24.0F);
-				fld.DenyNonAscii = true;
-				@fld.Changed = spades::ui::EventHandler(this.OnMaxDemosChanged);
-				AddChild(fld);
-				@fieldMaxDemos = fld;
-			}
-
-			AddLabel(0.0F, 96.0F, 30.0F, _Tr("StartupScreen", "Demos Folder"));
-			{
-				spades::ui::Button button(Manager);
-				string osType = helper.OperatingSystemType;
-				if (osType == "Windows") {
-					button.Caption = _Tr("StartupScreen", "Open Demos Folder in Explorer");
-				} else if (osType == "Mac") {
-					button.Caption = _Tr("StartupScreen", "Reveal Demos Folder in Finder");
-				} else {
-					button.Caption = _Tr("StartupScreen", "Browse Demos Folder");
-				}
-				button.Bounds = AABB2(160.0F, 96.0F, 350.0F, 30.0F);
-				@button.Activated = spades::ui::EventHandler(this.OnBrowseDemosFolderPressed);
-				AddChild(button);
-			}
-		}
-
-		void LoadConfig() {
-			buttonAutoRecord.Toggled = cg_demoAutoRecord.IntValue != 0;
-			buttonAutoPrune.Toggled = cg_demoAutoPrune.IntValue != 0;
-			fieldMaxDemos.Text = cg_demoMaxFiles.StringValue;
-		}
-
-		private void OnAutoRecordChanged(spades::ui::UIElement@) {
-			cg_demoAutoRecord.IntValue = buttonAutoRecord.Toggled ? 1 : 0;
-		}
-
-		private void OnAutoPruneChanged(spades::ui::UIElement@) {
-			cg_demoAutoPrune.IntValue = buttonAutoPrune.Toggled ? 1 : 0;
-		}
-
-		private void OnMaxDemosChanged(spades::ui::UIElement@) {
-			int v = ParseInt(fieldMaxDemos.Text);
-			if (v >= 1)
-				cg_demoMaxFiles.IntValue = v;
-		}
-
-		private void OnBrowseDemosFolderPressed(spades::ui::UIElement@) {
-			if (helper.BrowseDemosDirectory())
-				return;
-
-			string msg = _Tr("StartupScreen",
-							 "An unknown error has occurred while opening the demos directory.");
-			AlertScreen al(Parent, msg, 100.0F);
-			al.Run();
 		}
 	}
 

--- a/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
+++ b/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
@@ -633,6 +633,8 @@ namespace spades {
 		StartupScreenUI@ ui;
 		StartupScreenHelper@ helper;
 		StartupScreenLocaleEditor@ editLocale;
+		private spades::ui::CheckBox@ buttonAutoRecord;
+		private ConfigItem cg_autoRecord("cg_autoRecord");
 
 		StartupScreenGenericTab(StartupScreenUI@ ui, Vector2 size) {
 			super(ui.manager);
@@ -673,9 +675,26 @@ namespace spades {
 				@button.Activated = spades::ui::EventHandler(this.OnBrowseUserDirectoryPressed);
 				AddChild(button);
 			}
+
+			AddLabel(0.0F, 108.0F, 24.0F, _Tr("StartupScreen", "Demo Recording"));
+			{
+				spades::ui::CheckBox chk(Manager);
+				chk.Caption = _Tr("StartupScreen", "Automatically record every game");
+				chk.Bounds = AABB2(160.0F, 108.0F, 350.0F, 24.0F);
+				@chk.Activated = spades::ui::EventHandler(this.OnAutoRecordChanged);
+				AddChild(chk);
+				@buttonAutoRecord = chk;
+			}
 		}
 
-		void LoadConfig() { editLocale.LoadConfig(); }
+		void LoadConfig() {
+			editLocale.LoadConfig();
+			buttonAutoRecord.Toggled = cg_autoRecord.IntValue != 0;
+		}
+
+		private void OnAutoRecordChanged(spades::ui::UIElement@) {
+			cg_autoRecord.IntValue = buttonAutoRecord.Toggled ? 1 : 0;
+		}
 
 		private void OnBrowseUserDirectoryPressed(spades::ui::UIElement@) {
 			if (helper.BrowseUserDirectory())

--- a/Resources/Scripts/Gui/StartupScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/StartupScreen/MainMenu.as
@@ -36,7 +36,6 @@ namespace spades {
 		StartupScreenGraphicsTab@ graphicsTab;
 		StartupScreenAudioTab@ audioTab;
 		StartupScreenGenericTab@ genericTab;
-		StartupScreenRecordingTab@ recordingTab;
 		StartupScreenSystemInfoTab@ systemInfoTab;
 		StartupScreenAdvancedTab@ advancedTab;
 
@@ -94,25 +93,21 @@ namespace spades {
 			StartupScreenGraphicsTab graphicsTab(ui, clientArea.max - clientArea.min);
 			StartupScreenAudioTab audioTab(ui, clientArea.max - clientArea.min);
 			StartupScreenGenericTab genericTab(ui, clientArea.max - clientArea.min);
-			StartupScreenRecordingTab recordingTab(ui, clientArea.max - clientArea.min);
 			StartupScreenSystemInfoTab profileTab(ui, clientArea.max - clientArea.min);
 			StartupScreenAdvancedTab advancedTab(ui, clientArea.max - clientArea.min);
 			graphicsTab.Bounds = clientArea;
 			audioTab.Bounds = clientArea;
 			genericTab.Bounds = clientArea;
-			recordingTab.Bounds = clientArea;
 			profileTab.Bounds = clientArea;
 			advancedTab.Bounds = clientArea;
 			AddChild(graphicsTab);
 			AddChild(audioTab);
 			AddChild(genericTab);
-			AddChild(recordingTab);
 			AddChild(profileTab);
 			AddChild(advancedTab);
 			audioTab.Visible = false;
 			profileTab.Visible = false;
 			genericTab.Visible = false;
-			recordingTab.Visible = false;
 			advancedTab.Visible = false;
 
 			@this.graphicsTab = graphicsTab;
@@ -120,7 +115,6 @@ namespace spades {
 			@this.advancedTab = advancedTab;
 			@this.systemInfoTab = profileTab;
 			@this.genericTab = genericTab;
-			@this.recordingTab = recordingTab;
 
 			{
 				spades::ui::SimpleTabStrip tabStrip(Manager);
@@ -129,7 +123,6 @@ namespace spades {
 				tabStrip.AddItem(_Tr("StartupScreen", "Graphics"), graphicsTab);
 				tabStrip.AddItem(_Tr("StartupScreen", "Audio"), audioTab);
 				tabStrip.AddItem(_Tr("StartupScreen", "Generic"), genericTab);
-				tabStrip.AddItem(_Tr("StartupScreen", "Recording"), recordingTab);
 				tabStrip.AddItem(_Tr("StartupScreen", "System Info"), profileTab);
 				tabStrip.AddItem(_Tr("StartupScreen", "Advanced"), advancedTab);
 				@tabStrip.Changed = spades::ui::EventHandler(this.OnTabChanged);
@@ -175,7 +168,6 @@ namespace spades {
 			this.graphicsTab.LoadConfig();
 			this.audioTab.LoadConfig();
 			this.genericTab.LoadConfig();
-			this.recordingTab.LoadConfig();
 			this.advancedTab.LoadConfig();
 		}
 
@@ -187,12 +179,10 @@ namespace spades {
 				state.ActiveTabIndex = 1;
 			} else if (this.genericTab.Visible) {
 				state.ActiveTabIndex = 2;
-			} else if (this.recordingTab.Visible) {
-				state.ActiveTabIndex = 3;
 			} else if (this.systemInfoTab.Visible) {
-				state.ActiveTabIndex = 4;
+				state.ActiveTabIndex = 3;
 			} else if (this.advancedTab.Visible) {
-				state.ActiveTabIndex = 5;
+				state.ActiveTabIndex = 4;
 			}
 			return state;
 		}
@@ -201,9 +191,8 @@ namespace spades {
 			this.graphicsTab.Visible = state.ActiveTabIndex == 0;
 			this.audioTab.Visible = state.ActiveTabIndex == 1;
 			this.genericTab.Visible = state.ActiveTabIndex == 2;
-			this.recordingTab.Visible = state.ActiveTabIndex == 3;
-			this.systemInfoTab.Visible = state.ActiveTabIndex == 4;
-			this.advancedTab.Visible = state.ActiveTabIndex == 5;
+			this.systemInfoTab.Visible = state.ActiveTabIndex == 3;
+			this.advancedTab.Visible = state.ActiveTabIndex == 4;
 		}
 
 		private void OnBypassStartupWindowCheckChanged(spades::ui::UIElement@ sender) {

--- a/Resources/Scripts/Gui/StartupScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/StartupScreen/MainMenu.as
@@ -36,6 +36,7 @@ namespace spades {
 		StartupScreenGraphicsTab@ graphicsTab;
 		StartupScreenAudioTab@ audioTab;
 		StartupScreenGenericTab@ genericTab;
+		StartupScreenRecordingTab@ recordingTab;
 		StartupScreenSystemInfoTab@ systemInfoTab;
 		StartupScreenAdvancedTab@ advancedTab;
 
@@ -93,21 +94,25 @@ namespace spades {
 			StartupScreenGraphicsTab graphicsTab(ui, clientArea.max - clientArea.min);
 			StartupScreenAudioTab audioTab(ui, clientArea.max - clientArea.min);
 			StartupScreenGenericTab genericTab(ui, clientArea.max - clientArea.min);
+			StartupScreenRecordingTab recordingTab(ui, clientArea.max - clientArea.min);
 			StartupScreenSystemInfoTab profileTab(ui, clientArea.max - clientArea.min);
 			StartupScreenAdvancedTab advancedTab(ui, clientArea.max - clientArea.min);
 			graphicsTab.Bounds = clientArea;
 			audioTab.Bounds = clientArea;
 			genericTab.Bounds = clientArea;
+			recordingTab.Bounds = clientArea;
 			profileTab.Bounds = clientArea;
 			advancedTab.Bounds = clientArea;
 			AddChild(graphicsTab);
 			AddChild(audioTab);
 			AddChild(genericTab);
+			AddChild(recordingTab);
 			AddChild(profileTab);
 			AddChild(advancedTab);
 			audioTab.Visible = false;
 			profileTab.Visible = false;
 			genericTab.Visible = false;
+			recordingTab.Visible = false;
 			advancedTab.Visible = false;
 
 			@this.graphicsTab = graphicsTab;
@@ -115,6 +120,7 @@ namespace spades {
 			@this.advancedTab = advancedTab;
 			@this.systemInfoTab = profileTab;
 			@this.genericTab = genericTab;
+			@this.recordingTab = recordingTab;
 
 			{
 				spades::ui::SimpleTabStrip tabStrip(Manager);
@@ -123,6 +129,7 @@ namespace spades {
 				tabStrip.AddItem(_Tr("StartupScreen", "Graphics"), graphicsTab);
 				tabStrip.AddItem(_Tr("StartupScreen", "Audio"), audioTab);
 				tabStrip.AddItem(_Tr("StartupScreen", "Generic"), genericTab);
+				tabStrip.AddItem(_Tr("StartupScreen", "Recording"), recordingTab);
 				tabStrip.AddItem(_Tr("StartupScreen", "System Info"), profileTab);
 				tabStrip.AddItem(_Tr("StartupScreen", "Advanced"), advancedTab);
 				@tabStrip.Changed = spades::ui::EventHandler(this.OnTabChanged);
@@ -168,6 +175,7 @@ namespace spades {
 			this.graphicsTab.LoadConfig();
 			this.audioTab.LoadConfig();
 			this.genericTab.LoadConfig();
+			this.recordingTab.LoadConfig();
 			this.advancedTab.LoadConfig();
 		}
 
@@ -179,10 +187,12 @@ namespace spades {
 				state.ActiveTabIndex = 1;
 			} else if (this.genericTab.Visible) {
 				state.ActiveTabIndex = 2;
-			} else if (this.systemInfoTab.Visible) {
+			} else if (this.recordingTab.Visible) {
 				state.ActiveTabIndex = 3;
-			} else if (this.advancedTab.Visible) {
+			} else if (this.systemInfoTab.Visible) {
 				state.ActiveTabIndex = 4;
+			} else if (this.advancedTab.Visible) {
+				state.ActiveTabIndex = 5;
 			}
 			return state;
 		}
@@ -191,8 +201,9 @@ namespace spades {
 			this.graphicsTab.Visible = state.ActiveTabIndex == 0;
 			this.audioTab.Visible = state.ActiveTabIndex == 1;
 			this.genericTab.Visible = state.ActiveTabIndex == 2;
-			this.systemInfoTab.Visible = state.ActiveTabIndex == 3;
-			this.advancedTab.Visible = state.ActiveTabIndex == 4;
+			this.recordingTab.Visible = state.ActiveTabIndex == 3;
+			this.systemInfoTab.Visible = state.ActiveTabIndex == 4;
+			this.advancedTab.Visible = state.ActiveTabIndex == 5;
 		}
 
 		private void OnBypassStartupWindowCheckChanged(spades::ui::UIElement@ sender) {

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
+#include <fstream>
 
 #include "Client.h"
 #include "Fonts.h"
@@ -545,9 +546,17 @@ namespace spades {
 
 			if (isDemoMode) {
 				SPLog("Starting demo playback: '%s'", demoFilePath.c_str());
+
+				// Check if file exists
+				std::ifstream testFile(demoFilePath);
+				if (!testFile.good()) {
+					SPRaise("Demo file not found: %s", demoFilePath.c_str());
+				}
+				testFile.close();
+
 				demoNet = stmp::make_unique<DemoNetClient>(this);
 				if (!demoNet->OpenDemo(demoFilePath)) {
-					SPRaise("Failed to open demo file: %s", demoFilePath.c_str());
+					SPRaise("Failed to open demo file (invalid format?): %s", demoFilePath.c_str());
 				}
 			} else {
 				SPLog("Started connecting to '%s'", hostname.ToString().c_str());

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -75,7 +75,7 @@ namespace spades {
 		Client::Client(Handle<IRenderer> r, Handle<IAudioDevice> audioDev,
 					   const ServerAddress& host, Handle<FontManager> fontManager,
 					   const std::string& demoPath)
-			: isDemoMode(!demoPath.empty()),
+			: activeNet(nullptr),
 			  demoFilePath(demoPath),
 			  playerName(StripNewlines(cg_playerName.operator std::string()).substr(0, 15)),
 			  logStream(nullptr),
@@ -257,7 +257,7 @@ namespace spades {
 		}
 
 		void Client::ReloadDemo() {
-			if (!isDemoMode || demoFilePath.empty())
+			if (demoNet == nullptr || demoFilePath.empty())
 				return;
 
 			SetWorld(nullptr);
@@ -266,6 +266,7 @@ namespace spades {
 			demoNet = stmp::make_unique<DemoNetClient>(this);
 			if (!demoNet->OpenDemo(demoFilePath))
 				SPRaise("Failed to reload demo file: %s", demoFilePath.c_str());
+			activeNet = demoNet.get();
 		}
 
 		Client::~Client() {
@@ -579,7 +580,7 @@ namespace spades {
 			mumbleLink.SetContext(hostname.ToString(false));
 			mumbleLink.SetIdentity(playerName);
 
-			if (isDemoMode) {
+			if (!demoFilePath.empty()) {
 				SPLog("Starting demo playback: '%s'", demoFilePath.c_str());
 
 				// Check if file exists
@@ -593,10 +594,12 @@ namespace spades {
 				if (!demoNet->OpenDemo(demoFilePath)) {
 					SPRaise("Failed to open demo file (invalid format?): %s", demoFilePath.c_str());
 				}
+				activeNet = demoNet.get();
 			} else {
 				SPLog("Started connecting to '%s'", hostname.ToString().c_str());
 				net = stmp::make_unique<NetClient>(this);
 				net->Connect(hostname);
+				activeNet = net.get();
 			}
 
 			// get host/time string
@@ -650,16 +653,9 @@ namespace spades {
 
 			// update network or demo playback
 			try {
-				if (isDemoMode) {
-					demoNet->DoEvents(dt);
-				} else {
-					if (net->GetStatus() == NetClientStatusConnected)
-						net->DoEvents(0);
-					else
-						net->DoEvents(10);
-				}
+				activeNet->DoEvents(dt);
 			} catch (const std::exception& ex) {
-				NetClientStatus status = isDemoMode ? demoNet->GetStatus() : net->GetStatus();
+				NetClientStatus status = activeNet->GetStatus();
 				if (status == NetClientStatusNotConnected) {
 					SPLog("Disconnected because of error:\n%s", ex.what());
 					NetLog("Disconnected because of error:\n%s", ex.what());
@@ -696,7 +692,7 @@ namespace spades {
 			UpdateAutoFocus(dt);
 
 			if (world) {
-				float gameplayDt = (isDemoMode && demoNet) ? dt * demoNet->GetSpeed() : dt;
+				float gameplayDt = demoNet ? dt * demoNet->GetSpeed() : dt;
 				UpdateWorld(dt, gameplayDt);
 				mumbleLink.Update(world->GetLocalPlayer().get_pointer());
 			} else {
@@ -708,11 +704,10 @@ namespace spades {
 			limbo->Update(dt);
 
 			// The loading screen
-			NetClientStatus currentStatus = isDemoMode ? demoNet->GetStatus() : net->GetStatus();
+			NetClientStatus currentStatus = activeNet->GetStatus();
 			if (currentStatus == NetClientStatusReceivingMap) {
 				// Apply temporal smoothing on the progress value
-				float progress = isDemoMode ? demoNet->GetMapReceivingProgress()
-				                            : net->GetMapReceivingProgress();
+				float progress = activeNet->GetMapReceivingProgress();
 
 				if (mapReceivingProgressSmoothed > progress)
 					mapReceivingProgressSmoothed = progress;
@@ -764,7 +759,7 @@ namespace spades {
 
 		bool Client::IsLimboViewActive() {
 			// In demo mode, never show limbo view - user is spectating
-			if (isDemoMode)
+			if (IsDemoMode())
 				return false;
 			return world && (!world->GetLocalPlayer() || inGameLimbo);
 		}
@@ -782,7 +777,7 @@ namespace spades {
 				team = 255;
 
 			// In demo mode, player actions are replayed from the demo file
-			if (isDemoMode)
+			if (IsDemoMode())
 				return;
 
 			stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
@@ -792,7 +787,7 @@ namespace spades {
 					// NetClient doesn't like invalid weapon ID
 					weap = WeaponType::RIFLE_WEAPON;
 				}
-				net->SendJoin(team, weap, playerName, lastScore);
+				activeNet->SendJoin(team, weap, playerName, lastScore);
 			} else { // localplayer has joined
 				Player& p = maybePlayer.value();
 
@@ -800,9 +795,9 @@ namespace spades {
 				const auto curWeap = p.GetWeapon().GetWeaponType();
 
 				if (team != curTeam)
-					net->SendTeamChange(team);
+					activeNet->SendTeamChange(team);
 				if (team != 255 && weap != curWeap)
-					net->SendWeaponChange(weap);
+					activeNet->SendWeaponChange(weap);
 			}
 
 			// set loadout
@@ -1126,7 +1121,7 @@ namespace spades {
 			} while (nextId != startId);
 
 			followedPlayerId = nextId;
-			followCameraState.enabled = staffSpectating || isDemoMode || (followedPlayerId != localPlayerId);
+			followCameraState.enabled = staffSpectating || IsDemoMode() || (followedPlayerId != localPlayerId);
 		}
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -660,7 +660,8 @@ namespace spades {
 			UpdateAutoFocus(dt);
 
 			if (world) {
-				UpdateWorld(dt);
+				float gameplayDt = (isDemoMode && demoNet) ? dt * demoNet->GetSpeed() : dt;
+				UpdateWorld(dt, gameplayDt);
 				mumbleLink.Update(world->GetLocalPlayer().get_pointer());
 			} else {
 				renderer->SetFogColor(MakeVector3(0, 0, 0));

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -674,11 +674,14 @@ namespace spades {
 				demoSeekRepeatTimer += dt;
 				while (demoSeekRepeatTimer >= kRepeatInterval) {
 					demoSeekRepeatTimer -= kRepeatInterval;
+					float prev = demoSeekPendingTime;
+					float duration = demoNet->GetDuration();
 					if (demoSeekForwardHeld)
-						demoSeekPendingTime = demoSeekPendingTime + kSeekStep;
+						demoSeekPendingTime = std::min(duration, demoSeekPendingTime + kSeekStep);
 					if (demoSeekBackwardHeld)
 						demoSeekPendingTime = std::max(0.0f, demoSeekPendingTime - kSeekStep);
-					demoNet->SeekPreview(demoSeekPendingTime);
+					if (demoSeekPendingTime != prev)
+						demoNet->SeekPreview(demoSeekPendingTime);
 				}
 			}
 

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -665,6 +665,23 @@ namespace spades {
 				}
 			}
 
+			// Repeated seek preview while a seek key is held.
+			// Each repeat tick advances demoSeekPendingTime and calls SeekPreview() so the
+			// HUD updates smoothly.  The world-replay Seek() is deferred to key release.
+			if (demoNet && (demoSeekForwardHeld || demoSeekBackwardHeld)) {
+				constexpr float kSeekStep = 5.0f;
+				constexpr float kRepeatInterval = 0.35f;
+				demoSeekRepeatTimer += dt;
+				while (demoSeekRepeatTimer >= kRepeatInterval) {
+					demoSeekRepeatTimer -= kRepeatInterval;
+					if (demoSeekForwardHeld)
+						demoSeekPendingTime = demoSeekPendingTime + kSeekStep;
+					if (demoSeekBackwardHeld)
+						demoSeekPendingTime = std::max(0.0f, demoSeekPendingTime - kSeekStep);
+					demoNet->SeekPreview(demoSeekPendingTime);
+				}
+			}
+
 			hurtRingView->Update(dt);
 			centerMessageView->Update(dt);
 			mapView->Update(dt);

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -232,6 +232,30 @@ namespace spades {
 			worldSetTime = time;
 		}
 
+		Client::ViewState Client::SaveViewState() const {
+			ViewState s;
+			s.followEnabled = followCameraState.enabled;
+			s.followFirstPerson = followCameraState.firstPerson;
+			s.followedPlayerId = followedPlayerId;
+			s.freePosition = freeCameraState.position;
+			s.freeVelocity = freeCameraState.velocity;
+			s.yaw = followAndFreeCameraState.yaw;
+			s.pitch = followAndFreeCameraState.pitch;
+			s.worldSetTime = worldSetTime;
+			return s;
+		}
+
+		void Client::RestoreViewState(const ViewState& s) {
+			followCameraState.enabled = s.followEnabled;
+			followCameraState.firstPerson = s.followFirstPerson;
+			followedPlayerId = s.followedPlayerId;
+			freeCameraState.position = s.freePosition;
+			freeCameraState.velocity = s.freeVelocity;
+			followAndFreeCameraState.yaw = s.yaw;
+			followAndFreeCameraState.pitch = s.pitch;
+			worldSetTime = s.worldSetTime;
+		}
+
 		void Client::ReloadDemo() {
 			if (!isDemoMode || demoFilePath.empty())
 				return;

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -181,7 +181,10 @@ namespace spades {
 			// reset on new map
 			placedBlocks = 0;
 
-			staffSpectating = false;
+			// In demo replay, every seek calls SetWorld via ResetWorldForReplay;
+			// preserve the staff/ESP toggle across seeks.
+			if (!IsDemoMode())
+				staffSpectating = false;
 			reloadKeyPressed = false;
 			scoreboardVisible = false;
 			flashlightOn = false;

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <cstdarg>
+#include <cstdio>
 #include <cstdlib>
 #include <ctime>
 
@@ -71,8 +72,12 @@ namespace spades {
 	namespace client {
 
 		Client::Client(Handle<IRenderer> r, Handle<IAudioDevice> audioDev,
-					   const ServerAddress& host, Handle<FontManager> fontManager)
-			: playerName(StripNewlines(cg_playerName.operator std::string()).substr(0, 15)),
+					   const ServerAddress& host, Handle<FontManager> fontManager,
+					   const std::string& demoPath)
+			: isDemoMode(!demoPath.empty()),
+			  demoFilePath(demoPath),
+			  recordGameCount(0),
+			  playerName(StripNewlines(cg_playerName.operator std::string()).substr(0, 15)),
 			  logStream(nullptr),
 			  hostname(host),
 			  renderer(r),
@@ -151,8 +156,6 @@ namespace spades {
 			tcView = stmp::make_unique<TCProgressView>(*this);
 			scriptedUI = Handle<ClientUI>::New(renderer.GetPointerOrNull(),
 				audioDev.GetPointerOrNull(), fontManager.GetPointerOrNull(), this);
-
-			bloodMarks = stmp::make_unique<BloodMarks>(*this);
 
 			renderer->SetGameMap(nullptr);
 		}
@@ -244,6 +247,10 @@ namespace spades {
 				net->Disconnect();
 				net.reset();
 			}
+			if (demoNet) {
+				SPLog("Closing demo playback");
+				demoNet.reset();
+			}
 
 			SPLog("Disconnected");
 
@@ -271,6 +278,8 @@ namespace spades {
 		/** Initiate an initialization which likely to take some time */
 		void Client::DoInit() {
 			renderer->Init();
+
+			bloodMarks = stmp::make_unique<BloodMarks>(*this);
 
 			// load images
 			SmokeSpriteEntity::Preload(renderer.GetPointerOrNull());
@@ -534,9 +543,17 @@ namespace spades {
 			mumbleLink.SetContext(hostname.ToString(false));
 			mumbleLink.SetIdentity(playerName);
 
-			SPLog("Started connecting to '%s'", hostname.ToString().c_str());
-			net = stmp::make_unique<NetClient>(this);
-			net->Connect(hostname);
+			if (isDemoMode) {
+				SPLog("Starting demo playback: '%s'", demoFilePath.c_str());
+				demoNet = stmp::make_unique<DemoNetClient>(this);
+				if (!demoNet->OpenDemo(demoFilePath)) {
+					SPRaise("Failed to open demo file: %s", demoFilePath.c_str());
+				}
+			} else {
+				SPLog("Started connecting to '%s'", hostname.ToString().c_str());
+				net = stmp::make_unique<NetClient>(this);
+				net->Connect(hostname);
+			}
 
 			// get host/time string
 			std::string fn = hostname.ToString(false);
@@ -587,14 +604,19 @@ namespace spades {
 
 			timeSinceInit += std::min(dt, 0.03F);
 
-			// update network
+			// update network or demo playback
 			try {
-				if (net->GetStatus() == NetClientStatusConnected)
-					net->DoEvents(0);
-				else
-					net->DoEvents(10);
+				if (isDemoMode) {
+					demoNet->DoEvents(dt);
+				} else {
+					if (net->GetStatus() == NetClientStatusConnected)
+						net->DoEvents(0);
+					else
+						net->DoEvents(10);
+				}
 			} catch (const std::exception& ex) {
-				if (net->GetStatus() == NetClientStatusNotConnected) {
+				NetClientStatus status = isDemoMode ? demoNet->GetStatus() : net->GetStatus();
+				if (status == NetClientStatusNotConnected) {
 					SPLog("Disconnected because of error:\n%s", ex.what());
 					NetLog("Disconnected because of error:\n%s", ex.what());
 					throw;
@@ -641,9 +663,11 @@ namespace spades {
 			limbo->Update(dt);
 
 			// The loading screen
-			if (net->GetStatus() == NetClientStatusReceivingMap) {
+			NetClientStatus currentStatus = isDemoMode ? demoNet->GetStatus() : net->GetStatus();
+			if (currentStatus == NetClientStatusReceivingMap) {
 				// Apply temporal smoothing on the progress value
-				float progress = net->GetMapReceivingProgress();
+				float progress = isDemoMode ? demoNet->GetMapReceivingProgress()
+				                            : net->GetMapReceivingProgress();
 
 				if (mapReceivingProgressSmoothed > progress)
 					mapReceivingProgressSmoothed = progress;
@@ -694,6 +718,9 @@ namespace spades {
 		}
 
 		bool Client::IsLimboViewActive() {
+			// In demo mode, never show limbo view - user is spectating
+			if (isDemoMode)
+				return false;
 			return world && (!world->GetLocalPlayer() || inGameLimbo);
 		}
 
@@ -708,6 +735,10 @@ namespace spades {
 			int team = limbo->GetSelectedTeam();
 			if (team == 2)
 				team = 255;
+
+			// In demo mode, player actions are replayed from the demo file
+			if (isDemoMode)
+				return;
 
 			stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
 			if (!maybePlayer || maybePlayer->IsSpectator()) { // join
@@ -1002,20 +1033,30 @@ namespace spades {
 
 		void Client::FollowNextPlayer(bool reverse) {
 			stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
-			SPAssert(maybePlayer);
 
-			Player& localPlayer = maybePlayer.value();
+			// In demo mode, there's no local player - we're always spectating
+			bool localPlayerIsSpectating = true;
+			bool skipDeadPlayers = false;
+			int localPlayerId = -1;
 
-			bool localPlayerIsSpectador = localPlayer.IsSpectator();
-			bool localPlayerIsSpectating = localPlayerIsSpectador || staffSpectating;
-			bool skipDeadPlayers = !localPlayerIsSpectador && cg_skipDeadPlayersWhenDead;
+			if (maybePlayer) {
+				Player& localPlayer = maybePlayer.value();
+				bool localPlayerIsSpectador = localPlayer.IsSpectator();
+				localPlayerIsSpectating = localPlayerIsSpectador || staffSpectating;
+				skipDeadPlayers = !localPlayerIsSpectador && cg_skipDeadPlayersWhenDead;
+				localPlayerId = localPlayer.GetId();
+			}
 
-			int localPlayerId = localPlayer.GetId();
 			int nextId = FollowsNonLocalPlayer(GetCameraMode())
 				? followedPlayerId : localPlayerId;
 
 			auto slots = world->GetNumPlayerSlots();
 
+			// Ensure nextId is valid
+			if (nextId < 0 || nextId >= static_cast<int>(slots))
+				nextId = 0;
+
+			int startId = nextId;
 			do {
 				reverse ? --nextId : ++nextId;
 
@@ -1027,7 +1068,7 @@ namespace spades {
 				stmp::optional<Player&> p = world->GetPlayer(nextId);
 				if (!p || p->IsSpectator())
 					continue; // Do not follow a non-existent player or spectator
-				if (!localPlayerIsSpectating && !p->IsTeammate(localPlayer))
+				if (!localPlayerIsSpectating && maybePlayer && !p->IsTeammate(maybePlayer.value()))
 					continue; // Skip enemies unless the local player is a spectator
 				if (skipDeadPlayers && !p->IsAlive())
 					continue; // Skip dead players if the local player is not a spectator
@@ -1037,10 +1078,10 @@ namespace spades {
 					continue;
 
 				break;
-			} while (nextId != followedPlayerId);
+			} while (nextId != startId);
 
 			followedPlayerId = nextId;
-			followCameraState.enabled = staffSpectating || (followedPlayerId != localPlayerId);
+			followCameraState.enabled = staffSpectating || isDemoMode || (followedPlayerId != localPlayerId);
 		}
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -77,7 +77,6 @@ namespace spades {
 					   const std::string& demoPath)
 			: isDemoMode(!demoPath.empty()),
 			  demoFilePath(demoPath),
-			  recordGameCount(0),
 			  playerName(StripNewlines(cg_playerName.operator std::string()).substr(0, 15)),
 			  logStream(nullptr),
 			  hostname(host),

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -232,6 +232,18 @@ namespace spades {
 			worldSetTime = time;
 		}
 
+		void Client::ReloadDemo() {
+			if (!isDemoMode || demoFilePath.empty())
+				return;
+
+			SetWorld(nullptr);
+			demoNet.reset();
+
+			demoNet = stmp::make_unique<DemoNetClient>(this);
+			if (!demoNet->OpenDemo(demoFilePath))
+				SPRaise("Failed to reload demo file: %s", demoFilePath.c_str());
+		}
+
 		Client::~Client() {
 			SPADES_MARK_FUNCTION();
 

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -528,6 +528,20 @@ namespace spades {
 
 			void SetWorld(World*);
 			World* GetWorld() const { return world.get(); }
+
+			// Snapshot of all view-related state, used to preserve camera across demo seeks
+			struct ViewState {
+				bool followEnabled;
+				bool followFirstPerson;
+				int followedPlayerId;
+				Vector3 freePosition;
+				Vector3 freeVelocity;
+				float yaw;
+				float pitch;
+				float worldSetTime;
+			};
+			ViewState SaveViewState() const;
+			void RestoreViewState(const ViewState&);
 			void AddLocalEntity(std::unique_ptr<ILocalEntity>&& ent) {
 				localEntities.emplace_back(std::move(ent));
 			}

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -29,6 +29,7 @@
 #include <unordered_map>
 
 #include "ClientCameraMode.h"
+#include "DemoNetClient.h"
 #include "ILocalEntity.h"
 #include "IRenderer.h"
 #include "IWorldListener.h"
@@ -105,6 +106,10 @@ namespace spades {
 			FPSCounter upsCounter;
 
 			std::unique_ptr<NetClient> net;
+			std::unique_ptr<DemoNetClient> demoNet;
+			bool isDemoMode;
+			std::string demoFilePath;
+			int recordGameCount;
 			std::string playerName;
 			std::unique_ptr<IStream> logStream;
 
@@ -495,7 +500,11 @@ namespace spades {
 
 		public:
 			Client(Handle<IRenderer>, Handle<IAudioDevice>,
-				const ServerAddress& host, Handle<FontManager>);
+				const ServerAddress& host, Handle<FontManager>,
+				const std::string& demoPath = "");
+
+			bool IsDemoMode() const { return isDemoMode; }
+			DemoNetClient* GetDemoNetClient() { return demoNet.get(); }
 
 			void RunFrame(float dt) override;
 			void RunFrameLate(float dt) override;

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -109,7 +109,6 @@ namespace spades {
 			std::unique_ptr<DemoNetClient> demoNet;
 			bool isDemoMode;
 			std::string demoFilePath;
-			int recordGameCount;
 			std::string playerName;
 			std::unique_ptr<IStream> logStream;
 

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -30,6 +30,8 @@
 
 #include "ClientCameraMode.h"
 #include "DemoNetClient.h"
+#include "INetClient.h"
+#include "NetClient.h"
 #include "ILocalEntity.h"
 #include "IRenderer.h"
 #include "IWorldListener.h"
@@ -107,7 +109,7 @@ namespace spades {
 
 			std::unique_ptr<NetClient> net;
 			std::unique_ptr<DemoNetClient> demoNet;
-			bool isDemoMode;
+			INetClient* activeNet; // points to net.get() or demoNet.get(), never null after DoInit
 			std::string demoFilePath;
 			std::string playerName;
 			std::unique_ptr<IStream> logStream;
@@ -506,7 +508,7 @@ namespace spades {
 				const ServerAddress& host, Handle<FontManager>,
 				const std::string& demoPath = "");
 
-			bool IsDemoMode() const { return isDemoMode; }
+			bool IsDemoMode() const { return demoNet != nullptr; }
 			DemoNetClient* GetDemoNetClient() { return demoNet.get(); }
 			void ReloadDemo();
 

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -468,6 +468,7 @@ namespace spades {
 			void DrawBlockPaletteHUD(float y);
 			void DrawAlivePlayersCount();
 			void DrawPlayingTime();
+			void DrawRecordingIndicator();
 			void DrawHurtSprites();
 			void DrawScreenEffect(bool hurt, float fadeTime = 0.35F);
 			void DrawAlert();
@@ -488,6 +489,8 @@ namespace spades {
 
 			std::string ScreenShotPath();
 			void TakeScreenShot(bool sceneOnly, bool scoreboardOnly = false);
+
+			std::string BuildDemoContext();
 
 			std::string MapShotPath();
 			void TakeMapShot();

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -508,6 +508,7 @@ namespace spades {
 
 			bool IsDemoMode() const { return isDemoMode; }
 			DemoNetClient* GetDemoNetClient() { return demoNet.get(); }
+			void ReloadDemo();
 
 			void RunFrame(float dt) override;
 			void RunFrameLate(float dt) override;

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -429,7 +429,7 @@ namespace spades {
 			std::vector<Handle<IAudioChunk>> killSounds;
 			void LoadKillSounds();
 
-			void UpdateWorld(float dt);
+			void UpdateWorld(float dt, float gameplayDt);
 			void UpdateLocalSpectator(float dt);
 			void UpdateLocalPlayer(float dt);
 			void UpdateAutoFocus(float dt);

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -111,6 +111,15 @@ namespace spades {
 			std::unique_ptr<DemoNetClient> demoNet;
 			INetClient* activeNet; // points to net.get() or demoNet.get(), never null after DoInit
 			std::string demoFilePath;
+
+			// Seek-key hold state.
+			// While a seek key is held, SeekPreview() advances demoSeekPendingTime so
+			// the HUD stays responsive.  The full world-replay Seek() fires only on
+			// key release, avoiding one expensive reset/replay per repeat tick.
+			bool demoSeekForwardHeld = false;
+			bool demoSeekBackwardHeld = false;
+			float demoSeekRepeatTimer = 0.0f;   // accumulates dt between preview steps
+			float demoSeekPendingTime = 0.0f;   // target time to commit on key release
 			std::string playerName;
 			std::unique_ptr<IStream> logStream;
 

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -469,6 +469,7 @@ namespace spades {
 			void DrawAlivePlayersCount();
 			void DrawPlayingTime();
 			void DrawRecordingIndicator();
+			void DrawDemoPlaybackHUD();
 			void DrawHurtSprites();
 			void DrawScreenEffect(bool hurt, float fadeTime = 0.35F);
 			void DrawAlert();

--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -388,7 +388,8 @@ namespace spades {
 					if (toolRaiseState < 0.0F) {
 						toolRaiseState = 0.0F;
 						currentTool = player.GetTool();
-						client.net->SendTool();
+						if (!client.IsDemoMode())
+							client.net->SendTool();
 
 						// play tool change sound
 						IAudioDevice& audioDevice = client.GetAudioDevice();

--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -388,8 +388,7 @@ namespace spades {
 					if (toolRaiseState < 0.0F) {
 						toolRaiseState = 0.0F;
 						currentTool = player.GetTool();
-						if (!client.IsDemoMode())
-							client.net->SendTool();
+						client.activeNet->SendTool();
 
 						// play tool change sound
 						IAudioDevice& audioDevice = client.GetAudioDevice();

--- a/Sources/Client/ClientUI.cpp
+++ b/Sources/Client/ClientUI.cpp
@@ -63,7 +63,8 @@ namespace spades {
 		void ClientUI::SendChat(const std::string& msg, bool isGlobal) {
 			if (!client)
 				return;
-			client->net->SendChat(msg, isGlobal);
+			if (!client->IsDemoMode())
+				client->net->SendChat(msg, isGlobal);
 		}
 
 		void ClientUI::AlertNotice(const std::string& msg) {

--- a/Sources/Client/ClientUI.cpp
+++ b/Sources/Client/ClientUI.cpp
@@ -63,8 +63,7 @@ namespace spades {
 		void ClientUI::SendChat(const std::string& msg, bool isGlobal) {
 			if (!client)
 				return;
-			if (!client->IsDemoMode())
-				client->net->SendChat(msg, isGlobal);
+			client->activeNet->SendChat(msg, isGlobal);
 		}
 
 		void ClientUI::AlertNotice(const std::string& msg) {

--- a/Sources/Client/ClientUIHelper.cpp
+++ b/Sources/Client/ClientUIHelper.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "ClientUIHelper.h"
+#include "Client.h"
 #include "ClientUI.h"
 
 namespace spades {
@@ -56,6 +57,10 @@ namespace spades {
 		void ClientUIHelper::AlertError(const std::string& text) {
 			if (!ui) return;
 			ui->AlertError(text);
+		}
+
+		bool ClientUIHelper::IsDemoMode() const {
+			return ui && ui->client && ui->client->IsDemoMode();
 		}
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/ClientUIHelper.h
+++ b/Sources/Client/ClientUIHelper.h
@@ -43,6 +43,8 @@ namespace spades {
 			void AlertNotice(const std::string&);
 			void AlertWarning(const std::string&);
 			void AlertError(const std::string&);
+
+			bool IsDemoMode() const;
 		};
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/Client_Console.cpp
+++ b/Sources/Client/Client_Console.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Client.h"
+#include "NetClient.h"
 
 #include <Gui/ConsoleCommand.h>
 

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -258,7 +258,7 @@ namespace spades {
 		}
 
 		void Client::DrawDemoPlaybackHUD() {
-			if (!isDemoMode || !demoNet)
+			if (!IsDemoMode() || !demoNet)
 				return;
 
 			float sw = renderer->ScreenWidth();
@@ -328,12 +328,12 @@ namespace spades {
 		}
 
 		void Client::DrawRecordingIndicator() {
-			if (!net || !net->IsDemoRecording())
+			if (!activeNet->IsDemoRecording())
 				return;
 
 			float sw = renderer->ScreenWidth();
 
-			float recTime = net->GetDemoRecordingTime();
+			float recTime = activeNet->GetDemoRecordingTime();
 			int mins = static_cast<int>(recTime) / 60;
 			int secs = static_cast<int>(recTime) % 60;
 			char timeBuf[16];
@@ -1345,7 +1345,7 @@ namespace spades {
 			addLine(_Tr("Client", "Melee Kills: {0}", meleeKills));
 			addLine(_Tr("Client", "Grenade Kills: {0}", grenadeKills));
 
-			if (cg_playerStatsShowPlacedBlocks && !net->GetGameProperties()->isGameModeArena)
+			if (cg_playerStatsShowPlacedBlocks && !activeNet->GetGameProperties()->isGameModeArena)
 				addLine(_Tr("Client", "Blocks Placed: {0}", placedBlocks));
 		}
 
@@ -1459,7 +1459,7 @@ namespace spades {
 			stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
 
 			// In demo mode there's no local player, treat as spectator
-			bool localPlayerIsSpectator = isDemoMode || staffSpectating ||
+			bool localPlayerIsSpectator = IsDemoMode() || staffSpectating ||
 				(maybePlayer && maybePlayer->IsSpectator());
 
 			float x = sw - 8.0F;
@@ -1526,7 +1526,7 @@ namespace spades {
 
 			y += lh * 0.5F;
 
-			if (isDemoMode) {
+			if (IsDemoMode()) {
 				// Demo playback controls
 				std::string pauseLabel = (demoNet && demoNet->IsPaused())
 					? _Tr("Client", "[{0}] Resume", TrKey(cg_keyDemoPlayPause))
@@ -1781,7 +1781,7 @@ namespace spades {
 			} else {
 				// world exists, but no local player: not joined (or demo mode)
 
-				if (isDemoMode && shouldDrawHUD) {
+				if (IsDemoMode() && shouldDrawHUD) {
 					// Draw spectator HUD elements in demo mode
 					if (spectatorPlayerNames)
 						DrawPubOVL();
@@ -1807,7 +1807,7 @@ namespace spades {
 				}
 
 				// In demo mode, only show scoreboard when toggled
-				if (!isDemoMode || scoreboardVisible) {
+				if (!IsDemoMode() || scoreboardVisible) {
 					scoreboard->Draw();
 					DrawPlayingTime();
 				}
@@ -1845,7 +1845,7 @@ namespace spades {
 			renderer->DrawImage(nullptr, AABB2(prgBarX, prgBarY, prgBarW, prgBarH));
 
 			// draw progress bar
-			NetClientStatus status = isDemoMode ? demoNet->GetStatus() : net->GetStatus();
+			NetClientStatus status = activeNet->GetStatus();
 			if (status == NetClientStatusReceivingMap) {
 				float progress = mapReceivingProgressSmoothed;
 				float prgBarMaxWidth = prgBarW * progress;
@@ -1869,7 +1869,7 @@ namespace spades {
 			}
 
 			// draw net status
-			auto statusStr = isDemoMode ? demoNet->GetStatusString() : net->GetStatusString();
+			auto statusStr = activeNet->GetStatusString();
 			IFont& font = fontManager->GetGuiFont();
 			Vector2 size = font.Measure(statusStr);
 			Vector2 pos = MakeVector2((sw - size.x) * 0.5F, (prgBarY - 10.0F) - size.y);
@@ -1910,21 +1910,21 @@ namespace spades {
 				}
 			}
 
-			if (net) {
-				auto ping = net->GetPing();
+			if (!IsDemoMode()) {
+				auto ping = activeNet->GetPing();
 				snprintf(buf, sizeof(buf), ", ping: %dms", ping);
 				str += buf;
 
-				auto upbps = net->GetUplinkBps() / 1000;
-				auto downbps = net->GetDownlinkBps() / 1000;
+				auto upbps = activeNet->GetUplinkBps() / 1000;
+				auto downbps = activeNet->GetDownlinkBps() / 1000;
 				snprintf(buf, sizeof(buf), ", up/down: %.02f/%.02fkbps", upbps, downbps);
 				str += buf;
 
-				auto loss = net->GetPacketLoss() * 100.0F;
+				auto loss = activeNet->GetPacketLoss() * 100.0F;
 				snprintf(buf, sizeof(buf), ", loss: %.0f%%", loss);
 				str += buf;
 
-				auto throttle = net->GetPacketThrottle();
+				auto throttle = activeNet->GetPacketThrottle();
 				auto choke = (1.0F - throttle) * 100.0F;
 				snprintf(buf, sizeof(buf), ", choke: %.0f%%", choke);
 				str += buf;

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -347,8 +347,19 @@ namespace spades {
 			std::string label = std::string(dotVisible ? "\xe2\x97\x8f " : "  ") + "REC " + timeBuf;
 
 			Vector2 size = font.Measure(label);
-			float x = (sw - size.x) * 0.5F;
-			float y = 8.0F;
+
+			// Place top-right, just below the minimap, to avoid overlapping it or
+			// the centered playing-time clock. Mirror the minimap's y offset for
+			// the stats bar, then add the minimap height and a gap.
+			const float margin = 8.0F;
+			float minimapY = margin;
+			const int statsMode = cg_stats;
+			if (statsMode == 2 || (statsMode >= 3 && scoreboardVisible))
+				minimapY += cg_statsSmallFont ? 10.0F : 20.0F;
+			float minimapSize = Clamp((float)cg_minimapSize, 32.0F, 256.0F);
+			// Align with the minimap top, placed to its left
+			float y = minimapY;
+			float x = sw - margin - minimapSize - margin - size.x;
 
 			Vector4 red = MakeVector4(1, 0.15F, 0.15F, 1);
 			Vector4 shadow = MakeVector4(0, 0, 0, 0.5F);

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -68,6 +68,8 @@ SPADES_SETTING(cg_keyDemoPlayPause);
 SPADES_SETTING(cg_keyDemoSeekForward);
 SPADES_SETTING(cg_keyDemoSeekBackward);
 SPADES_SETTING(cg_keyDemoRecord);
+SPADES_SETTING(cg_keyDemoSpeedUp);
+SPADES_SETTING(cg_keyDemoSlowDown);
 DEFINE_SPADES_SETTING(cg_screenshotFormat, "jpeg");
 DEFINE_SPADES_SETTING(cg_stats, "0");
 DEFINE_SPADES_SETTING(cg_statsSmallFont, "0");
@@ -253,6 +255,76 @@ namespace spades {
 			Vector2 size = font.Measure(str);
 			Vector2 pos = (MakeVector2(sw, sh) - 16.0F) - size;
 			font.DrawShadow(str, pos, 1.0F, MakeVector4(1, 1, 1, 1), MakeVector4(0, 0, 0, 0.5));
+		}
+
+		void Client::DrawDemoPlaybackHUD() {
+			if (!isDemoMode || !demoNet)
+				return;
+
+			float sw = renderer->ScreenWidth();
+			float sh = renderer->ScreenHeight();
+
+			float duration = demoNet->GetDuration();
+			float cur = demoNet->GetTime();
+			float progress = (duration > 0.0f) ? (cur / duration) : 0.0f;
+
+			IFont& font = fontManager->GetGuiFont();
+
+			// --- progress bar geometry ---
+			const float barH = 4.0F;
+			const float margin = 8.0F;
+			const float barY = sh - margin - barH;
+			const float barW = sw - 2.0F * margin;
+
+			// background
+			renderer->SetColorAlphaPremultiplied(MakeVector4(0, 0, 0, 0.5F));
+			renderer->DrawFilledRect(margin, barY, margin + barW, barY + barH);
+
+			// filled portion
+			bool isPaused = demoNet->IsPaused();
+			Vector4 barColor = isPaused
+				? MakeVector4(0.7F, 0.7F, 0.7F, 1)
+				: MakeVector4(0.2F, 0.8F, 1.0F, 1);
+			renderer->SetColorAlphaPremultiplied(barColor);
+			renderer->DrawFilledRect(margin, barY, margin + barW * progress, barY + barH);
+
+			// --- time labels ---
+			auto fmtTime = [](float t) -> std::string {
+				int mins = static_cast<int>(t) / 60;
+				int secs = static_cast<int>(t) % 60;
+				char buf[16];
+				snprintf(buf, sizeof(buf), "%d:%02d", mins, secs);
+				return buf;
+			};
+
+			std::string curStr = fmtTime(cur);
+			std::string durStr = fmtTime(duration);
+
+			Vector4 white = MakeVector4(1, 1, 1, 1);
+			Vector4 shadow = MakeVector4(0, 0, 0, 0.5F);
+
+			float textY = barY - font.Measure(curStr).y - 4.0F;
+
+			// current time (left)
+			font.DrawShadow(curStr, MakeVector2(margin, textY), 1.0F, white, shadow);
+
+			// duration (right)
+			Vector2 durSize = font.Measure(durStr);
+			font.DrawShadow(durStr, MakeVector2(margin + barW - durSize.x, textY), 1.0F, white, shadow);
+
+			// speed indicator (center)
+			char speedBuf[16];
+			float spd = demoNet->GetSpeed();
+			if (spd == 1.0f)
+				snprintf(speedBuf, sizeof(speedBuf), "%.0fx", spd);
+			else
+				snprintf(speedBuf, sizeof(speedBuf), "%.2gx", spd);
+			std::string speedStr = isPaused
+				? std::string("|| ") + speedBuf
+				: std::string("> ") + speedBuf;
+			Vector2 speedSize = font.Measure(speedStr);
+			font.DrawShadow(speedStr, MakeVector2((sw - speedSize.x) * 0.5F, textY), 1.0F,
+				isPaused ? MakeVector4(0.8F, 0.8F, 0.8F, 1) : white, shadow);
 		}
 
 		void Client::DrawRecordingIndicator() {
@@ -1445,9 +1517,18 @@ namespace spades {
 
 			if (isDemoMode) {
 				// Demo playback controls
-				addLine(_Tr("Client", "[{0}] Play/Pause", TrKey(cg_keyDemoPlayPause)));
-				addLine(_Tr("Client", "[{0}/{1}] Seek fwd/back",
+				std::string pauseLabel = (demoNet && demoNet->IsPaused())
+					? _Tr("Client", "[{0}] Resume", TrKey(cg_keyDemoPlayPause))
+					: _Tr("Client", "[{0}] Pause", TrKey(cg_keyDemoPlayPause));
+				addLine(pauseLabel);
+				addLine(_Tr("Client", "[{0}/{1}] Seek +/-5s",
 					TrKey(cg_keyDemoSeekForward), TrKey(cg_keyDemoSeekBackward)));
+
+				char speedBuf[16];
+				float spd = demoNet ? demoNet->GetSpeed() : 1.0f;
+				snprintf(speedBuf, sizeof(speedBuf), "%.2gx", spd);
+				addLine(_Tr("Client", "[{0}/{1}] Speed: {2}",
+					TrKey(cg_keyDemoSlowDown), TrKey(cg_keyDemoSpeedUp), std::string(speedBuf)));
 			} else if (!inGameLimbo) {
 				addLine(_Tr("Client", "[{0}] Select Team/Weapon", TrKey(cg_keyLimbo)));
 			}
@@ -1726,6 +1807,7 @@ namespace spades {
 			if (cg_stats && shouldDrawHUD)
 				DrawStats();
 
+			DrawDemoPlaybackHUD();
 			DrawRecordingIndicator();
 
 			// draw limbo view (above everything)

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -64,6 +64,7 @@ SPADES_SETTING(cg_keyAltAttack);
 SPADES_SETTING(cg_keyCrouch);
 SPADES_SETTING(cg_keyLimbo);
 SPADES_SETTING(cg_keyToggleSpectatorNames);
+SPADES_SETTING(cg_keyStaffSpectating);
 SPADES_SETTING(cg_keyDemoPlayPause);
 SPADES_SETTING(cg_keyDemoSeekForward);
 SPADES_SETTING(cg_keyDemoSeekBackward);
@@ -318,6 +319,15 @@ namespace spades {
 			// duration (right)
 			Vector2 durSize = font.Measure(durStr);
 			font.DrawShadow(durStr, MakeVector2(margin + barW - durSize.x, textY), 1.0F, white, shadow);
+
+			// ESP-toggle hint stacked above the time row
+			std::string espStr = _Tr("Client", "[{0}] ESP: {1}",
+				TrKey(cg_keyStaffSpectating), staffSpectating ? "ON" : "OFF");
+			float hintY = textY - font.Measure(espStr).y - 2.0F;
+			Vector4 hintCol = staffSpectating
+				? MakeVector4(0.2F, 1.0F, 0.4F, 1)
+				: MakeVector4(0.85F, 0.85F, 0.85F, 1);
+			font.DrawShadow(espStr, MakeVector2(margin, hintY), 1.0F, hintCol, shadow);
 
 			// speed indicator (center)
 			char speedBuf[16];
@@ -758,7 +768,7 @@ namespace spades {
 					continue;
 
 				const auto& color = GetPlayerColor(p);
-				if (staffSpectating || demoNet)
+				if (staffSpectating)
 					DrawPlayerBox(p, color);
 				if (spectatorPlayerNames)
 					DrawPlayerName(p, color);

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -67,6 +67,7 @@ SPADES_SETTING(cg_keyToggleSpectatorNames);
 SPADES_SETTING(cg_keyDemoPlayPause);
 SPADES_SETTING(cg_keyDemoSeekForward);
 SPADES_SETTING(cg_keyDemoSeekBackward);
+SPADES_SETTING(cg_keyDemoRecord);
 DEFINE_SPADES_SETTING(cg_screenshotFormat, "jpeg");
 DEFINE_SPADES_SETTING(cg_stats, "0");
 DEFINE_SPADES_SETTING(cg_statsSmallFont, "0");
@@ -252,6 +253,34 @@ namespace spades {
 			Vector2 size = font.Measure(str);
 			Vector2 pos = (MakeVector2(sw, sh) - 16.0F) - size;
 			font.DrawShadow(str, pos, 1.0F, MakeVector4(1, 1, 1, 1), MakeVector4(0, 0, 0, 0.5));
+		}
+
+		void Client::DrawRecordingIndicator() {
+			if (!net || !net->IsDemoRecording())
+				return;
+
+			float sw = renderer->ScreenWidth();
+
+			float recTime = net->GetDemoRecordingTime();
+			int mins = static_cast<int>(recTime) / 60;
+			int secs = static_cast<int>(recTime) % 60;
+			char timeBuf[16];
+			snprintf(timeBuf, sizeof(timeBuf), "%d:%02d", mins, secs);
+
+			IFont& font = fontManager->GetGuiFont();
+
+			// Blinking red dot: visible 0.6 s, hidden 0.4 s
+			bool dotVisible = fmodf(time, 1.0F) < 0.6F;
+
+			std::string label = std::string(dotVisible ? "\xe2\x97\x8f " : "  ") + "REC " + timeBuf;
+
+			Vector2 size = font.Measure(label);
+			float x = (sw - size.x) * 0.5F;
+			float y = 8.0F;
+
+			Vector4 red = MakeVector4(1, 0.15F, 0.15F, 1);
+			Vector4 shadow = MakeVector4(0, 0, 0, 0.5F);
+			font.DrawShadow(label, MakeVector2(x, y), 1.0F, red, shadow);
 		}
 
 		void Client::DrawPlayingTime() {
@@ -1696,6 +1725,8 @@ namespace spades {
 
 			if (cg_stats && shouldDrawHUD)
 				DrawStats();
+
+			DrawRecordingIndicator();
 
 			// draw limbo view (above everything)
 			if (IsLimboViewActive() && !scriptedUI->NeedsInput())

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -731,7 +731,10 @@ namespace spades {
 			bool isFollowingNonLocal = FollowsNonLocalPlayer(cameraMode);
 
 			int focusPlayerId = GetCameraTargetPlayerId();
-			auto maybeFocusPlayer = world->GetPlayer(focusPlayerId);
+			stmp::optional<Player&> maybeFocusPlayer;
+			if (focusPlayerId >= 0
+			 && static_cast<size_t>(focusPlayerId) < world->GetNumPlayerSlots())
+				maybeFocusPlayer = world->GetPlayer(static_cast<unsigned int>(focusPlayerId));
 
 			for (size_t i = 0; i < world->GetNumPlayerSlots(); i++) {
 				auto maybePlayer = world->GetPlayer(static_cast<unsigned int>(i));

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -1539,8 +1539,10 @@ namespace spades {
 			if (localPlayerIsSpectator) {
 				addLine(_Tr("Client", "[{0}] Toggle player names",
 					TrKey(cg_keyToggleSpectatorNames)));
-				addLine(_Tr("Client", "[{0}] Toggle ESP",
-					TrKey(cg_keyStaffSpectating)));
+				bool isStaff = activeNet && activeNet->GetGameProperties()->isStaff;
+				if (isStaff || IsDemoMode())
+					addLine(_Tr("Client", "[{0}] Toggle ESP",
+						TrKey(cg_keyStaffSpectating)));
 			}
 
 			y += lh * 0.5F;

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -320,15 +320,6 @@ namespace spades {
 			Vector2 durSize = font.Measure(durStr);
 			font.DrawShadow(durStr, MakeVector2(margin + barW - durSize.x, textY), 1.0F, white, shadow);
 
-			// ESP-toggle hint stacked above the time row
-			std::string espStr = _Tr("Client", "[{0}] ESP: {1}",
-				TrKey(cg_keyStaffSpectating), staffSpectating ? "ON" : "OFF");
-			float hintY = textY - font.Measure(espStr).y - 2.0F;
-			Vector4 hintCol = staffSpectating
-				? MakeVector4(0.2F, 1.0F, 0.4F, 1)
-				: MakeVector4(0.85F, 0.85F, 0.85F, 1);
-			font.DrawShadow(espStr, MakeVector2(margin, hintY), 1.0F, hintCol, shadow);
-
 			// speed indicator (center)
 			char speedBuf[16];
 			float spd = demoNet->GetSpeed();
@@ -1545,9 +1536,12 @@ namespace spades {
 				addLine(_Tr("Client", "[{0}/{1}] Go up/down",
 					TrKey(cg_keyJump), TrKey(cg_keyCrouch)));
 
-			if (localPlayerIsSpectator)
+			if (localPlayerIsSpectator) {
 				addLine(_Tr("Client", "[{0}] Toggle player names",
 					TrKey(cg_keyToggleSpectatorNames)));
+				addLine(_Tr("Client", "[{0}] Toggle ESP",
+					TrKey(cg_keyStaffSpectating)));
+			}
 
 			y += lh * 0.5F;
 

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -271,9 +271,12 @@ namespace spades {
 			IFont& font = fontManager->GetGuiFont();
 
 			// --- progress bar geometry ---
+			// Reserve a strip below the bar so it sits above the bottom-anchored
+			// FPS/stats line (DrawStats with cg_stats == 1) instead of overlapping it.
 			const float barH = 4.0F;
 			const float margin = 8.0F;
-			const float barY = sh - margin - barH;
+			const float bottomReserve = font.Measure("X").y + 4.0F;
+			const float barY = sh - margin - barH - bottomReserve;
 			const float barW = sw - 2.0F * margin;
 
 			// background

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -754,9 +754,10 @@ namespace spades {
 					continue;
 
 				const auto& color = GetPlayerColor(p);
-				if (staffSpectating)
+				if (staffSpectating || demoNet)
 					DrawPlayerBox(p, color);
-				DrawPlayerName(p, color);
+				if (spectatorPlayerNames)
+					DrawPlayerName(p, color);
 			}
 		}
 
@@ -1792,9 +1793,9 @@ namespace spades {
 				// world exists, but no local player: not joined (or demo mode)
 
 				if (IsDemoMode() && shouldDrawHUD) {
-					// Draw spectator HUD elements in demo mode
-					if (spectatorPlayerNames)
-						DrawPubOVL();
+					// Draw spectator HUD elements in demo mode.
+					// Boxes always render (staff use); names follow the toggle.
+					DrawPubOVL();
 
 					tcView->Draw();
 

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -64,6 +64,9 @@ SPADES_SETTING(cg_keyAltAttack);
 SPADES_SETTING(cg_keyCrouch);
 SPADES_SETTING(cg_keyLimbo);
 SPADES_SETTING(cg_keyToggleSpectatorNames);
+SPADES_SETTING(cg_keyDemoPlayPause);
+SPADES_SETTING(cg_keyDemoSeekForward);
+SPADES_SETTING(cg_keyDemoSeekBackward);
 DEFINE_SPADES_SETTING(cg_screenshotFormat, "jpeg");
 DEFINE_SPADES_SETTING(cg_stats, "0");
 DEFINE_SPADES_SETTING(cg_statsSmallFont, "0");
@@ -608,7 +611,8 @@ namespace spades {
 			auto cameraMode = GetCameraMode();
 			bool isFollowingNonLocal = FollowsNonLocalPlayer(cameraMode);
 
-			auto& focusPlayer = GetCameraTargetPlayer();
+			int focusPlayerId = GetCameraTargetPlayerId();
+			auto maybeFocusPlayer = world->GetPlayer(focusPlayerId);
 
 			for (size_t i = 0; i < world->GetNumPlayerSlots(); i++) {
 				auto maybePlayer = world->GetPlayer(static_cast<unsigned int>(i));
@@ -620,7 +624,7 @@ namespace spades {
 					continue; // don't draw dead players or spectators
 
 				// dont draw the focused player name when following non-local players
-				if (&p == &focusPlayer && isFollowingNonLocal)
+				if (maybeFocusPlayer && &p == &maybeFocusPlayer.value() && isFollowingNonLocal)
 					continue;
 
 				// Do not draw a player with an invalid state
@@ -1340,9 +1344,11 @@ namespace spades {
 			float sw = renderer->ScreenWidth();
 			float sh = renderer->ScreenHeight();
 
-			Player& p = world->GetLocalPlayer().value();
+			stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
 
-			bool localPlayerIsSpectator = p.IsSpectator() || staffSpectating;
+			// In demo mode there's no local player, treat as spectator
+			bool localPlayerIsSpectator = isDemoMode || staffSpectating ||
+				(maybePlayer && maybePlayer->IsSpectator());
 
 			float x = sw - 8.0F;
 			float minY = sh * 0.5F;
@@ -1369,10 +1375,11 @@ namespace spades {
 			auto cameraMode = GetCameraMode();
 
 			int playerId = GetCameraTargetPlayerId();
-			auto& camTarget = world->GetPlayer(playerId).value();
+			auto maybeCamTarget = world->GetPlayer(playerId);
 
 			// Help messages (make sure to synchronize these with the keyboard input handler)
-			if (FollowsNonLocalPlayer(cameraMode)) {
+			if (FollowsNonLocalPlayer(cameraMode) && maybeCamTarget) {
+				Player& camTarget = maybeCamTarget.value();
 				if (HasTargetPlayer(cameraMode)) {
 					addLine(_Tr("Client", "Following {0} [#{1}]",
 						world->GetPlayerName(playerId), playerId));
@@ -1392,7 +1399,7 @@ namespace spades {
 
 				if (localPlayerIsSpectator)
 					addLine(_Tr("Client", "[{0}] Unfollow", TrKey(cg_keyReloadWeapon)));
-			} else {
+			} else if (!FollowsNonLocalPlayer(cameraMode)) {
 				addLine(_Tr("Client", "[{0}/{1}] Follow a player",
 					TrKey(cg_keyAttack), TrKey(cg_keyAltAttack)));
 			}
@@ -1407,8 +1414,14 @@ namespace spades {
 
 			y += lh * 0.5F;
 
-			if (!inGameLimbo)
+			if (isDemoMode) {
+				// Demo playback controls
+				addLine(_Tr("Client", "[{0}] Play/Pause", TrKey(cg_keyDemoPlayPause)));
+				addLine(_Tr("Client", "[{0}/{1}] Seek fwd/back",
+					TrKey(cg_keyDemoSeekForward), TrKey(cg_keyDemoSeekBackward)));
+			} else if (!inGameLimbo) {
 				addLine(_Tr("Client", "[{0}] Select Team/Weapon", TrKey(cg_keyLimbo)));
+			}
 		}
 
 		void Client::DrawBlockPaletteHUD(float winY) {
@@ -1646,6 +1659,31 @@ namespace spades {
 				// --- end "player is there" render
 			} else {
 				// world exists, but no local player: not joined (or demo mode)
+
+				if (isDemoMode && shouldDrawHUD) {
+					// Draw spectator HUD elements in demo mode
+					if (spectatorPlayerNames)
+						DrawPubOVL();
+
+					tcView->Draw();
+
+					if (cg_hudPlayerCount)
+						DrawAlivePlayersCount();
+
+					// Draw map
+					bool largeMap = largeMapView->IsZoomed();
+					if (!largeMap)
+						mapView->Draw();
+
+					DrawSpectateHUD();
+
+					chatWindow->Draw();
+					killfeedWindow->Draw();
+
+					// Large map view should come in front
+					if (largeMap)
+						largeMapView->Draw();
+				}
 
 				// In demo mode, only show scoreboard when toggled
 				if (!isDemoMode || scoreboardVisible) {

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -1796,6 +1796,15 @@ namespace spades {
 					if (!largeMap)
 						mapView->Draw();
 
+					// When following a player in first-person, draw their weapon
+					// skin's 2D layer (crosshair / iron sights / scope).
+					if (IsFirstPerson(GetCameraMode())) {
+						int targetId = GetCameraTargetPlayerId();
+						auto maybeTarget = world->GetPlayer(targetId);
+						if (maybeTarget && maybeTarget->IsAlive())
+							clientPlayers[targetId]->Draw2D();
+					}
+
 					DrawSpectateHUD();
 
 					chatWindow->Draw();

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -589,11 +589,15 @@ namespace spades {
 			float fade = (sqrtf(dist) - fadeStart) / (fadeEnd - fadeStart);
 			float alpha = Clamp(1.0F - fade, 0.1F, 1.0F);
 
-			dir = dir.Normalize();
-
-			// do map raycast
+			// camera coincides with the player's eye (e.g. mid-spectator-switch);
+			// skip the raycast since direction is undefined
 			GameMap::RayCastResult mapResult;
-			mapResult = map->CastRay2(eye, dir, 256);
+			if (dir.GetSquaredLength() < 1.0e-6F) {
+				mapResult.hit = false;
+			} else {
+				dir = dir.Normalize();
+				mapResult = map->CastRay2(eye, dir, 256);
+			}
 
 			if (dist > FOG_DISTANCE_SQ) {
 				playerColor = MakeVector4(1, 0.75, 0, 1);

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -328,12 +328,12 @@ namespace spades {
 		}
 
 		void Client::DrawRecordingIndicator() {
-			if (!activeNet->IsDemoRecording())
+			if (!net || !net->IsDemoRecording())
 				return;
 
 			float sw = renderer->ScreenWidth();
 
-			float recTime = activeNet->GetDemoRecordingTime();
+			float recTime = net->GetDemoRecordingTime();
 			int mins = static_cast<int>(recTime) / 60;
 			int secs = static_cast<int>(recTime) % 60;
 			char timeBuf[16];

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -273,9 +273,13 @@ namespace spades {
 			// --- progress bar geometry ---
 			// Reserve a strip below the bar so it sits above the bottom-anchored
 			// FPS/stats line (DrawStats with cg_stats == 1) instead of overlapping it.
+			// When cg_hudPlayerCount == 2 the alive-count team bar also anchors at the
+			// bottom-center, so lift the demo HUD above it as well.
 			const float barH = 4.0F;
 			const float margin = 8.0F;
-			const float bottomReserve = font.Measure("X").y + 4.0F;
+			float bottomReserve = font.Measure("X").y + 4.0F;
+			if ((int)cg_hudPlayerCount == 2)
+				bottomReserve += 48.0F; // clears the 40px team bar plus padding
 			const float barY = sh - margin - barH - bottomReserve;
 			const float barW = sw - 2.0F * margin;
 

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -1645,10 +1645,13 @@ namespace spades {
 
 				// --- end "player is there" render
 			} else {
-				// world exists, but no local player: not joined
+				// world exists, but no local player: not joined (or demo mode)
 
-				scoreboard->Draw();
-				DrawPlayingTime();
+				// In demo mode, only show scoreboard when toggled
+				if (!isDemoMode || scoreboardVisible) {
+					scoreboard->Draw();
+					DrawPlayingTime();
+				}
 				centerMessageView->Draw();
 				DrawAlert();
 			}
@@ -1680,7 +1683,8 @@ namespace spades {
 			renderer->DrawImage(nullptr, AABB2(prgBarX, prgBarY, prgBarW, prgBarH));
 
 			// draw progress bar
-			if (net->GetStatus() == NetClientStatusReceivingMap) {
+			NetClientStatus status = isDemoMode ? demoNet->GetStatus() : net->GetStatus();
+			if (status == NetClientStatusReceivingMap) {
 				float progress = mapReceivingProgressSmoothed;
 				float prgBarMaxWidth = prgBarW * progress;
 
@@ -1703,7 +1707,7 @@ namespace spades {
 			}
 
 			// draw net status
-			auto statusStr = net->GetStatusString();
+			auto statusStr = isDemoMode ? demoNet->GetStatusString() : net->GetStatusString();
 			IFont& font = fontManager->GetGuiFont();
 			Vector2 size = font.Measure(statusStr);
 			Vector2 pos = MakeVector2((sw - size.x) * 0.5F, (prgBarY - 10.0F) - size.y);

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -642,6 +642,8 @@ namespace spades {
 						}
 					} else if (CheckKey(cg_keyScoreboard, name)) {
 						scoreboardVisible = down;
+					} else if (CheckKey(cg_keyZoomChatLog, name)) {
+						chatWindow->SetExpanded(down);
 					}
 					return;
 				}

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -494,7 +494,8 @@ namespace spades {
 							}
 							return;
 						} else if (CheckKey(cg_keyJump, name)) {
-							if (down && GetCameraTargetPlayer().IsAlive())
+							auto maybeTarget = world->GetPlayer(GetCameraTargetPlayerId());
+							if (down && maybeTarget && maybeTarget->IsAlive())
 								followCameraState.firstPerson = !followCameraState.firstPerson;
 							return;
 						} else if (CheckKey(cg_keyReloadWeapon, name) && followCameraState.enabled) {
@@ -533,6 +534,33 @@ namespace spades {
 						playerInput.sprint = down;
 					} else if (CheckKey(cg_keyJump, name)) {
 						playerInput.jump = down;
+					}
+
+					// Handle map controls in demo mode
+					if (CheckKey(cg_keyChangeMapScale, name) && down) {
+						if (!largeMapView->IsZoomed()) {
+							renderer->UpdateFlatGameMap();
+							mapView->SwitchScale();
+							Handle<IAudioChunk> c =
+							  audioDevice->RegisterSound("Sounds/Misc/SwitchMapZoom.opus");
+							audioDevice->PlayLocal(c.GetPointerOrNull(), AudioParam());
+						}
+					} else if (CheckKey(cg_keyToggleMapZoom, name)) {
+						if (down || cg_holdMapZoom) {
+							bool zoomed = largeMapView->IsZoomed();
+							zoomed = !zoomed;
+							if (cg_holdMapZoom)
+								zoomed = down;
+
+							renderer->UpdateFlatGameMap();
+							largeMapView->SetZoom(zoomed);
+							Handle<IAudioChunk> c = zoomed
+								? audioDevice->RegisterSound("Sounds/Misc/OpenMap.opus")
+								: audioDevice->RegisterSound("Sounds/Misc/CloseMap.opus");
+							audioDevice->PlayLocal(c.GetPointerOrNull(), AudioParam());
+						}
+					} else if (CheckKey(cg_keyScoreboard, name)) {
+						scoreboardVisible = down;
 					}
 					return;
 				}
@@ -629,7 +657,8 @@ namespace spades {
 							}
 							return;
 						} else if (CheckKey(cg_keyJump, name) && cameraMode != ClientCameraMode::Free) {
-							if (down && GetCameraTargetPlayer().IsAlive())
+							auto maybeTarget = world->GetPlayer(GetCameraTargetPlayerId());
+							if (down && maybeTarget && maybeTarget->IsAlive())
 								followCameraState.firstPerson = !followCameraState.firstPerson;
 							return;
 						} else if (CheckKey(cg_keyReloadWeapon, name)

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -424,18 +424,38 @@ namespace spades {
 						return;
 					}
 
-					// Handle demo seeking (arrow keys)
-					if (CheckKey(cg_keyDemoSeekForward, name) && down) {
+					// Handle demo seeking (arrow keys).
+					//
+					// While a seek key is held we only call SeekPreview(), which updates the
+					// displayed playback position cheaply (no world reset/replay). RunFrame
+					// advances the pending target on each repeat tick.  The full Seek() —
+					// which resets and replays the world — fires once on key release so the
+					// expensive operation happens at most once per key press.
+					if (CheckKey(cg_keyDemoSeekForward, name)) {
 						if (demoNet) {
-							float newTime = demoNet->GetTime() + 5.0f;
-							demoNet->Seek(newTime);
+							if (down) {
+								demoSeekForwardHeld = true;
+								demoSeekRepeatTimer = 0.0f;
+								demoSeekPendingTime = demoNet->GetTime() + 5.0f;
+								demoNet->SeekPreview(demoSeekPendingTime);
+							} else {
+								demoSeekForwardHeld = false;
+								demoNet->Seek(demoSeekPendingTime);
+							}
 						}
 						return;
 					}
-					if (CheckKey(cg_keyDemoSeekBackward, name) && down) {
+					if (CheckKey(cg_keyDemoSeekBackward, name)) {
 						if (demoNet) {
-							float newTime = demoNet->GetTime() - 5.0f;
-							demoNet->Seek(std::max(0.0f, newTime));
+							if (down) {
+								demoSeekBackwardHeld = true;
+								demoSeekRepeatTimer = 0.0f;
+								demoSeekPendingTime = std::max(0.0f, demoNet->GetTime() - 5.0f);
+								demoNet->SeekPreview(demoSeekPendingTime);
+							} else {
+								demoSeekBackwardHeld = false;
+								demoNet->Seek(demoSeekPendingTime);
+							}
 						}
 						return;
 					}

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -108,8 +108,8 @@ DEFINE_SPADES_SETTING(cg_keyDemoSeekBackward, "Left");
 DEFINE_SPADES_SETTING(cg_keyDemoRecord, "F9");
 DEFINE_SPADES_SETTING(cg_keyDemoSpeedUp, "]");
 DEFINE_SPADES_SETTING(cg_keyDemoSlowDown, "[");
-SPADES_SETTING(cg_maxDemos);
-SPADES_SETTING(cg_autoPruneDemos);
+SPADES_SETTING(cg_demoMaxFiles);
+SPADES_SETTING(cg_demoAutoPrune);
 
 SPADES_SETTING(s_volume);
 DEFINE_SPADES_SETTING(cg_keyVolumeUp, "+");
@@ -723,8 +723,8 @@ namespace spades {
 						  _Tr("Client", "Demo recording stopped."), MsgColorSysInfo));
 					} else {
 						if (net->StartDemoRecording("", BuildDemoContext())) {
-							if ((int)cg_autoPruneDemos != 0) {
-								int maxDemos = (int)cg_maxDemos;
+							if ((int)cg_demoAutoPrune != 0) {
+								int maxDemos = (int)cg_demoMaxFiles;
 								if (maxDemos >= 1)
 									DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
 							}

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -109,6 +109,7 @@ DEFINE_SPADES_SETTING(cg_keyDemoRecord, "F9");
 DEFINE_SPADES_SETTING(cg_keyDemoSpeedUp, "]");
 DEFINE_SPADES_SETTING(cg_keyDemoSlowDown, "[");
 SPADES_SETTING(cg_maxDemos);
+SPADES_SETTING(cg_autoPruneDemos);
 
 SPADES_SETTING(s_volume);
 DEFINE_SPADES_SETTING(cg_keyVolumeUp, "+");
@@ -722,10 +723,11 @@ namespace spades {
 						  _Tr("Client", "Demo recording stopped."), MsgColorSysInfo));
 					} else {
 						if (net->StartDemoRecording("", BuildDemoContext())) {
-							int maxDemos = (int)cg_maxDemos;
-							if (maxDemos < 1)
-								maxDemos = 1;
-							DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
+							if ((int)cg_autoPruneDemos != 0) {
+								int maxDemos = (int)cg_maxDemos;
+								if (maxDemos >= 1)
+									DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
+							}
 							chatWindow->AddMessage(ChatWindow::ColoredMessage(
 							  _Tr("Client", "Demo recording started: {0}", net->GetDemoFilename()),
 							  MsgColorSysInfo));

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -105,6 +105,8 @@ DEFINE_SPADES_SETTING(cg_keyStaffSpectating, "f5");
 DEFINE_SPADES_SETTING(cg_keyDemoPlayPause, "P");
 DEFINE_SPADES_SETTING(cg_keyDemoSeekForward, "Right");
 DEFINE_SPADES_SETTING(cg_keyDemoSeekBackward, "Left");
+DEFINE_SPADES_SETTING(cg_keyDemoRecord, "F9");
+SPADES_SETTING(cg_maxDemos);
 
 SPADES_SETTING(s_volume);
 DEFINE_SPADES_SETTING(cg_keyVolumeUp, "+");
@@ -680,6 +682,29 @@ namespace spades {
 						}
 						break;
 					}
+				}
+
+				// demo record toggle â accessible for both players and spectators
+				if (CheckKey(cg_keyDemoRecord, name) && down && net) {
+					if (net->IsDemoRecording()) {
+						net->StopDemoRecording();
+						chatWindow->AddMessage(ChatWindow::ColoredMessage(
+						  _Tr("Client", "Demo recording stopped."), MsgColorSysInfo));
+					} else {
+						if (net->StartDemoRecording("", BuildDemoContext())) {
+							int maxDemos = (int)cg_maxDemos;
+							if (maxDemos < 1)
+								maxDemos = 1;
+							DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
+							chatWindow->AddMessage(ChatWindow::ColoredMessage(
+							  _Tr("Client", "Demo recording started: {0}", net->GetDemoFilename()),
+							  MsgColorSysInfo));
+						} else {
+							chatWindow->AddMessage(ChatWindow::ColoredMessage(
+							  _Tr("Client", "Failed to start demo recording."), MsgColorSysInfo));
+						}
+					}
+					return;
 				}
 
 				// player is not spectating

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -778,6 +778,7 @@ namespace spades {
 				if (CheckKey(cg_keyDemoRecord, name) && down && !IsDemoMode()) {
 					if (net->IsDemoRecording()) {
 						net->StopDemoRecording();
+						ShowAlert(_Tr("Client", "Recording stopped"), AlertType::Notice);
 					} else {
 						if (net->StartDemoRecording("", BuildDemoContext())) {
 							if ((int)cg_demoAutoPrune != 0) {
@@ -786,9 +787,10 @@ namespace spades {
 									DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
 							}
 							SPLog("Demo recording started: %s", net->GetDemoFilename().c_str());
+							ShowAlert(_Tr("Client", "Recording demo"), AlertType::Notice);
 						} else {
-							chatWindow->AddMessage(ChatWindow::ColoredMessage(
-							  _Tr("Client", "Failed to start demo recording."), MsgColorSysInfo));
+							ShowAlert(_Tr("Client", "Failed to start demo recording"),
+							          AlertType::Error);
 						}
 					}
 					return;

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -425,6 +425,15 @@ namespace spades {
 						return;
 					}
 
+					// Toggle ESP boxes (same surface as the staff-spectate toggle in live).
+					if (CheckKey(cg_keyStaffSpectating, name) && down) {
+						staffSpectating = !staffSpectating;
+						Handle<IAudioChunk> c =
+						  audioDevice->RegisterSound("Sounds/Player/Flashlight.opus");
+						audioDevice->PlayLocal(c.GetPointerOrNull(), AudioParam());
+						return;
+					}
+
 					// Handle demo playback controls (play/pause)
 					if (CheckKey(cg_keyDemoPlayPause, name) && down) {
 						if (demoNet) {

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -449,10 +449,14 @@ namespace spades {
 					if (CheckKey(cg_keyDemoSeekForward, name)) {
 						if (demoNet) {
 							if (down) {
-								demoSeekForwardHeld = true;
-								demoSeekRepeatTimer = 0.0f;
-								demoSeekPendingTime = demoNet->GetTime() + 5.0f;
-								demoNet->SeekPreview(demoSeekPendingTime);
+								float duration = demoNet->GetDuration();
+								float target = std::min(duration, demoNet->GetTime() + 5.0f);
+								if (target > demoNet->GetTime()) {
+									demoSeekForwardHeld = true;
+									demoSeekRepeatTimer = 0.0f;
+									demoSeekPendingTime = target;
+									demoNet->SeekPreview(demoSeekPendingTime);
+								}
 							} else {
 								demoSeekForwardHeld = false;
 								demoNet->Seek(demoSeekPendingTime);
@@ -463,10 +467,13 @@ namespace spades {
 					if (CheckKey(cg_keyDemoSeekBackward, name)) {
 						if (demoNet) {
 							if (down) {
-								demoSeekBackwardHeld = true;
-								demoSeekRepeatTimer = 0.0f;
-								demoSeekPendingTime = std::max(0.0f, demoNet->GetTime() - 5.0f);
-								demoNet->SeekPreview(demoSeekPendingTime);
+								float target = std::max(0.0f, demoNet->GetTime() - 5.0f);
+								if (target < demoNet->GetTime()) {
+									demoSeekBackwardHeld = true;
+									demoSeekRepeatTimer = 0.0f;
+									demoSeekPendingTime = target;
+									demoNet->SeekPreview(demoSeekPendingTime);
+								}
 							} else {
 								demoSeekBackwardHeld = false;
 								demoNet->Seek(demoSeekPendingTime);

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -409,7 +409,7 @@ namespace spades {
 				stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
 
 				// In demo mode, we're always spectating without a local player
-				if (isDemoMode) {
+				if (IsDemoMode()) {
 					// Handle demo playback controls (play/pause)
 					if (CheckKey(cg_keyDemoPlayPause, name) && down) {
 						if (demoNet) {
@@ -612,7 +612,7 @@ namespace spades {
 				bool localPlayerIsAlive = p.IsAlive();
 				bool localPlayerIsSpectator = p.IsSpectator();
 				bool localPlayerIsSpectating = localPlayerIsSpectator || staffSpectating;
-				bool isStaff = net ? net->GetGameProperties()->isStaff : false;
+				bool isStaff = activeNet->GetGameProperties()->isStaff;
 
 				// Pie menu: hold to open, release to commit.
 				// Aim at a teammate to send a DM; otherwise broadcast on team chat.
@@ -722,17 +722,17 @@ namespace spades {
 				}
 
 				// demo record toggle â accessible for both players and spectators
-				if (CheckKey(cg_keyDemoRecord, name) && down && net) {
-					if (net->IsDemoRecording()) {
-						net->StopDemoRecording();
+				if (CheckKey(cg_keyDemoRecord, name) && down && !IsDemoMode()) {
+					if (activeNet->IsDemoRecording()) {
+						activeNet->StopDemoRecording();
 					} else {
-						if (net->StartDemoRecording("", BuildDemoContext())) {
+						if (activeNet->StartDemoRecording("", BuildDemoContext())) {
 							if ((int)cg_demoAutoPrune != 0) {
 								int maxDemos = (int)cg_demoMaxFiles;
 								if (maxDemos >= 1)
 									DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
 							}
-							SPLog("Demo recording started: %s", net->GetDemoFilename().c_str());
+							SPLog("Demo recording started: %s", activeNet->GetDemoFilename().c_str());
 						} else {
 							chatWindow->AddMessage(ChatWindow::ColoredMessage(
 							  _Tr("Client", "Failed to start demo recording."), MsgColorSysInfo));

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -719,8 +719,6 @@ namespace spades {
 				if (CheckKey(cg_keyDemoRecord, name) && down && net) {
 					if (net->IsDemoRecording()) {
 						net->StopDemoRecording();
-						chatWindow->AddMessage(ChatWindow::ColoredMessage(
-						  _Tr("Client", "Demo recording stopped."), MsgColorSysInfo));
 					} else {
 						if (net->StartDemoRecording("", BuildDemoContext())) {
 							if ((int)cg_demoAutoPrune != 0) {
@@ -728,9 +726,7 @@ namespace spades {
 								if (maxDemos >= 1)
 									DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
 							}
-							chatWindow->AddMessage(ChatWindow::ColoredMessage(
-							  _Tr("Client", "Demo recording started: {0}", net->GetDemoFilename()),
-							  MsgColorSysInfo));
+							SPLog("Demo recording started: %s", net->GetDemoFilename().c_str());
 						} else {
 							chatWindow->AddMessage(ChatWindow::ColoredMessage(
 							  _Tr("Client", "Failed to start demo recording."), MsgColorSysInfo));

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -723,16 +723,16 @@ namespace spades {
 
 				// demo record toggle â accessible for both players and spectators
 				if (CheckKey(cg_keyDemoRecord, name) && down && !IsDemoMode()) {
-					if (activeNet->IsDemoRecording()) {
-						activeNet->StopDemoRecording();
+					if (net->IsDemoRecording()) {
+						net->StopDemoRecording();
 					} else {
-						if (activeNet->StartDemoRecording("", BuildDemoContext())) {
+						if (net->StartDemoRecording("", BuildDemoContext())) {
 							if ((int)cg_demoAutoPrune != 0) {
 								int maxDemos = (int)cg_demoMaxFiles;
 								if (maxDemos >= 1)
 									DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
 							}
-							SPLog("Demo recording started: %s", activeNet->GetDemoFilename().c_str());
+							SPLog("Demo recording started: %s", net->GetDemoFilename().c_str());
 						} else {
 							chatWindow->AddMessage(ChatWindow::ColoredMessage(
 							  _Tr("Client", "Failed to start demo recording."), MsgColorSysInfo));

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -541,6 +541,12 @@ namespace spades {
 								followCameraState.enabled = false;
 							}
 							return;
+						} else if (CheckKey(cg_keyToggleSpectatorNames, name) && down) {
+							spectatorPlayerNames = !spectatorPlayerNames;
+							Handle<IAudioChunk> c =
+							  audioDevice->RegisterSound("Sounds/Player/Flashlight.opus");
+							audioDevice->PlayLocal(c.GetPointerOrNull(), AudioParam());
+							return;
 						}
 					}
 

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -106,6 +106,8 @@ DEFINE_SPADES_SETTING(cg_keyDemoPlayPause, "P");
 DEFINE_SPADES_SETTING(cg_keyDemoSeekForward, "Right");
 DEFINE_SPADES_SETTING(cg_keyDemoSeekBackward, "Left");
 DEFINE_SPADES_SETTING(cg_keyDemoRecord, "F9");
+DEFINE_SPADES_SETTING(cg_keyDemoSpeedUp, "]");
+DEFINE_SPADES_SETTING(cg_keyDemoSlowDown, "[");
 SPADES_SETTING(cg_maxDemos);
 
 SPADES_SETTING(s_volume);
@@ -433,6 +435,34 @@ namespace spades {
 						if (demoNet) {
 							float newTime = demoNet->GetTime() - 5.0f;
 							demoNet->Seek(std::max(0.0f, newTime));
+						}
+						return;
+					}
+
+					// Speed control: step through preset multipliers
+					static const float speedSteps[] = {0.25f, 0.5f, 1.0f, 2.0f, 4.0f};
+					static const int numSpeedSteps = 5;
+					if (CheckKey(cg_keyDemoSpeedUp, name) && down) {
+						if (demoNet) {
+							float cur = demoNet->GetSpeed();
+							for (int i = 0; i < numSpeedSteps - 1; i++) {
+								if (cur < speedSteps[i] * 1.1f) {
+									demoNet->SetSpeed(speedSteps[i + 1]);
+									break;
+								}
+							}
+						}
+						return;
+					}
+					if (CheckKey(cg_keyDemoSlowDown, name) && down) {
+						if (demoNet) {
+							float cur = demoNet->GetSpeed();
+							for (int i = numSpeedSteps - 1; i > 0; i--) {
+								if (cur > speedSteps[i] * 0.9f) {
+									demoNet->SetSpeed(speedSteps[i - 1]);
+									break;
+								}
+							}
 						}
 						return;
 					}

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -410,6 +410,21 @@ namespace spades {
 
 				// In demo mode, we're always spectating without a local player
 				if (IsDemoMode()) {
+					// Allow screenshot / mapshot keys during playback — they don't
+					// require a local player and are commonly used to capture demos.
+					if (CheckKey(cg_keySceneshot, name) && down) {
+						TakeScreenShot(true);
+						return;
+					}
+					if (CheckKey(cg_keyScreenshot, name) && down) {
+						TakeScreenShot(false);
+						return;
+					}
+					if (CheckKey(cg_keySaveMap, name) && down) {
+						TakeMapShot();
+						return;
+					}
+
 					// Handle demo playback controls (play/pause)
 					if (CheckKey(cg_keyDemoPlayPause, name) && down) {
 						if (demoNet) {

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -106,8 +106,8 @@ DEFINE_SPADES_SETTING(cg_keyDemoPlayPause, "P");
 DEFINE_SPADES_SETTING(cg_keyDemoSeekForward, "Right");
 DEFINE_SPADES_SETTING(cg_keyDemoSeekBackward, "Left");
 DEFINE_SPADES_SETTING(cg_keyDemoRecord, "F9");
-DEFINE_SPADES_SETTING(cg_keyDemoSpeedUp, "]");
-DEFINE_SPADES_SETTING(cg_keyDemoSlowDown, "[");
+DEFINE_SPADES_SETTING(cg_keyDemoSpeedUp, ".");
+DEFINE_SPADES_SETTING(cg_keyDemoSlowDown, ",");
 SPADES_SETTING(cg_demoMaxFiles);
 SPADES_SETTING(cg_demoAutoPrune);
 

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -414,8 +414,8 @@ namespace spades {
 					if (CheckKey(cg_keyDemoPlayPause, name) && down) {
 						if (demoNet) {
 							if (demoNet->IsFinished()) {
-								// Demo finished - seek to beginning and resume
-								demoNet->SeekToBeginning();
+								// Demo finished - reload from file to reset world state
+								ReloadDemo();
 							} else {
 								// Toggle pause
 								demoNet->TogglePause();

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -102,6 +102,9 @@ DEFINE_SPADES_SETTING(cg_keyAutoFocus, "MiddleMouseButton");
 DEFINE_SPADES_SETTING(cg_keyToggleSpectatorNames, "z");
 DEFINE_SPADES_SETTING(cg_keySpectatorZoom, "e");
 DEFINE_SPADES_SETTING(cg_keyStaffSpectating, "f5");
+DEFINE_SPADES_SETTING(cg_keyDemoPlayPause, "P");
+DEFINE_SPADES_SETTING(cg_keyDemoSeekForward, "Right");
+DEFINE_SPADES_SETTING(cg_keyDemoSeekBackward, "Left");
 
 SPADES_SETTING(s_volume);
 DEFINE_SPADES_SETTING(cg_keyVolumeUp, "+");
@@ -399,6 +402,141 @@ namespace spades {
 				auto cameraMode = GetCameraMode();
 
 				stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
+
+				// In demo mode, we're always spectating without a local player
+				if (isDemoMode) {
+					// Handle demo playback controls (play/pause)
+					if (CheckKey(cg_keyDemoPlayPause, name) && down) {
+						if (demoNet) {
+							if (demoNet->IsFinished()) {
+								// Demo finished - seek to beginning and resume
+								demoNet->SeekToBeginning();
+							} else {
+								// Toggle pause
+								demoNet->TogglePause();
+							}
+						}
+						return;
+					}
+
+					// Handle demo seeking (arrow keys)
+					if (CheckKey(cg_keyDemoSeekForward, name) && down) {
+						if (demoNet) {
+							float newTime = demoNet->GetTime() + 5.0f;
+							demoNet->Seek(newTime);
+						}
+						return;
+					}
+					if (CheckKey(cg_keyDemoSeekBackward, name) && down) {
+						if (demoNet) {
+							float newTime = demoNet->GetTime() - 5.0f;
+							demoNet->Seek(std::max(0.0f, newTime));
+						}
+						return;
+					}
+
+					// Handle demo spectator controls
+					if (cameraMode == ClientCameraMode::Free) {
+						if (CheckKey(cg_keyAttack, name)) {
+							if (down) {
+								// reset zoom
+								if (spectatorZoom) {
+									spectatorZoom = false;
+									spectatorZoomState = 0.0F;
+								}
+								// Start following the recorded player
+								if (demoNet)
+									followedPlayerId = demoNet->GetRecordedLocalPlayerId();
+								FollowNextPlayer(false);
+							}
+							return;
+						} else if (CheckKey(cg_keyAltAttack, name)) {
+							if (down) {
+								// reset zoom
+								if (spectatorZoom) {
+									spectatorZoom = false;
+									spectatorZoomState = 0.0F;
+								}
+								// Start following the recorded player
+								if (demoNet)
+									followedPlayerId = demoNet->GetRecordedLocalPlayerId();
+								FollowNextPlayer(true);
+							}
+							return;
+						} else if (CheckKey(cg_keyToggleSpectatorNames, name) && down) {
+							spectatorPlayerNames = !spectatorPlayerNames;
+							Handle<IAudioChunk> c =
+							  audioDevice->RegisterSound("Sounds/Player/Flashlight.opus");
+							audioDevice->PlayLocal(c.GetPointerOrNull(), AudioParam());
+							return;
+						} else if (CheckKey(cg_keySpectatorZoom, name)) {
+							spectatorZoom = down;
+							return;
+						}
+					} else if (cameraMode == ClientCameraMode::FirstPersonFollow ||
+					           cameraMode == ClientCameraMode::ThirdPersonFollow) {
+						if (CheckKey(cg_keyAttack, name)) {
+							if (down) {
+								if (spectatorZoom) {
+									spectatorZoom = false;
+									spectatorZoomState = 0.0F;
+								}
+								FollowNextPlayer(false);
+							}
+							return;
+						} else if (CheckKey(cg_keyAltAttack, name)) {
+							if (down) {
+								if (spectatorZoom) {
+									spectatorZoom = false;
+									spectatorZoomState = 0.0F;
+								}
+								FollowNextPlayer(true);
+							}
+							return;
+						} else if (CheckKey(cg_keyJump, name)) {
+							if (down && GetCameraTargetPlayer().IsAlive())
+								followCameraState.firstPerson = !followCameraState.firstPerson;
+							return;
+						} else if (CheckKey(cg_keyReloadWeapon, name) && followCameraState.enabled) {
+							if (down) {
+								playerInput.jump = PlayerInput().jump;
+								if (spectatorZoom) {
+									spectatorZoom = false;
+									spectatorZoomState = 0.0F;
+								}
+								followCameraState.enabled = false;
+							}
+							return;
+						}
+					}
+
+					// Handle movement for demo spectator free camera
+					if (CheckKey(cg_keyMoveLeft, name)) {
+						playerInput.moveLeft = down;
+						keypadInput.left = down;
+						playerInput.moveRight = down ? false : keypadInput.right;
+					} else if (CheckKey(cg_keyMoveRight, name)) {
+						playerInput.moveRight = down;
+						keypadInput.right = down;
+						playerInput.moveLeft = down ? false : keypadInput.left;
+					} else if (CheckKey(cg_keyMoveForward, name)) {
+						playerInput.moveForward = down;
+						keypadInput.forward = down;
+						playerInput.moveBackward = down ? false : keypadInput.backward;
+					} else if (CheckKey(cg_keyMoveBackward, name)) {
+						playerInput.moveBackward = down;
+						keypadInput.backward = down;
+						playerInput.moveForward = down ? false : keypadInput.forward;
+					} else if (CheckKey(cg_keyCrouch, name)) {
+						playerInput.crouch = down;
+					} else if (CheckKey(cg_keySprint, name)) {
+						playerInput.sprint = down;
+					} else if (CheckKey(cg_keyJump, name)) {
+						playerInput.jump = down;
+					}
+					return;
+				}
+
 				if (!maybePlayer)
 					return;
 

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -72,11 +72,15 @@ namespace spades {
 			}
 			if (net && net->GetGameProperties()->isGameModeArena)
 				modeName = "arena";
-			std::string ctx = modeName;
-			if (!g_pendingMapName.empty())
-				ctx += "-" + DemoRecorder::SanitizeComponent(g_pendingMapName);
+
+			// Field order: server-map-gamemode
+			// Each field is sanitized so '-' never appears within a field.
+			std::string ctx;
 			if (!g_pendingServerName.empty())
-				ctx += "-" + DemoRecorder::SanitizeComponent(g_pendingServerName);
+				ctx += DemoRecorder::SanitizeComponent(g_pendingServerName) + "-";
+			if (!g_pendingMapName.empty())
+				ctx += DemoRecorder::SanitizeComponent(g_pendingMapName) + "-";
+			ctx += modeName;
 			return ctx;
 		}
 

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -51,8 +51,6 @@ DEFINE_SPADES_SETTING(cg_autoScreenshot, "0");
 DEFINE_SPADES_SETTING(cg_autoRecord, "0");
 
 namespace spades {
-	extern std::string g_recordDemoPath;
-	extern bool g_autoRecordDemo;
 	extern std::string g_pendingMapName;
 	extern std::string g_pendingServerName;
 
@@ -149,20 +147,11 @@ namespace spades {
 				return ctx;
 			};
 
-			// start recording if --record was specified, or auto-record is enabled
-			if (net) {
-				const bool doAutoRecord = g_autoRecordDemo || (int)cg_autoRecord != 0;
-				if (!g_recordDemoPath.empty()) {
-					recordGameCount++;
-					std::string filename = g_recordDemoPath + "_" + std::to_string(recordGameCount) + ".dem";
-					if (net->StartDemoRecording(filename)) {
-						SPLog("Started recording demo: %s", net->GetDemoFilename().c_str());
-					}
-				} else if (doAutoRecord) {
-					if (net->StartDemoRecording("", buildHostContext())) {
-						SPLog("Started auto-recording demo: %s", net->GetDemoFilename().c_str());
-						DemoRecorder::PruneOldRecordings(10);
-					}
+			// start recording if auto-record is enabled
+			if (net && (int)cg_autoRecord != 0) {
+				if (net->StartDemoRecording("", buildHostContext())) {
+					SPLog("Started auto-recording demo: %s", net->GetDemoFilename().c_str());
+					DemoRecorder::PruneOldRecordings(10);
 				}
 			}
 		}

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -53,6 +53,8 @@ DEFINE_SPADES_SETTING(cg_autoRecord, "0");
 namespace spades {
 	extern std::string g_recordDemoPath;
 	extern bool g_autoRecordDemo;
+	extern std::string g_pendingMapName;
+	extern std::string g_pendingServerName;
 
 	namespace client {
 
@@ -123,18 +125,27 @@ namespace spades {
 			std::string s = _Tr("Client", "You are connected with {0} ({2}) on {1}", verStr, osInfo, archInfo);
 			chatWindow->AddMessage(ChatWindow::ColoredMessage(s, MsgColorSysInfo));
 
-			// build sanitized hostname string for use in demo filenames
+			// build demo filename context: gamemode-mapname-serveraddress
 			auto buildHostContext = [&]() -> std::string {
-				std::string host = hostname.ToString(false);
-				std::string ctx;
-				for (char c : host) {
-					if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))
-						ctx += c;
-					else
-						ctx += '_';
-					if (ctx.size() >= 32)
-						break;
+				// game mode
+				std::string modeName = "game";
+				if (world) {
+					auto gmode = world->GetMode();
+					if (gmode) {
+						switch (gmode->ModeType()) {
+							case IGameMode::m_CTF: modeName = "ctf"; break;
+							case IGameMode::m_TC: modeName = "tc"; break;
+						}
+					}
 				}
+				if (net && net->GetGameProperties()->isGameModeArena)
+					modeName = "arena";
+
+				std::string ctx = modeName;
+				if (!g_pendingMapName.empty())
+					ctx += "-" + DemoRecorder::SanitizeComponent(g_pendingMapName);
+				if (!g_pendingServerName.empty())
+					ctx += "-" + DemoRecorder::SanitizeComponent(g_pendingServerName);
 				return ctx;
 			};
 

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -59,6 +59,27 @@ namespace spades {
 
 #pragma mark - Server Packet Handlers
 
+		std::string Client::BuildDemoContext() {
+			std::string modeName = "game";
+			if (world) {
+				auto gmode = world->GetMode();
+				if (gmode) {
+					switch (gmode->ModeType()) {
+						case IGameMode::m_CTF: modeName = "ctf"; break;
+						case IGameMode::m_TC: modeName = "tc"; break;
+					}
+				}
+			}
+			if (net && net->GetGameProperties()->isGameModeArena)
+				modeName = "arena";
+			std::string ctx = modeName;
+			if (!g_pendingMapName.empty())
+				ctx += "-" + DemoRecorder::SanitizeComponent(g_pendingMapName);
+			if (!g_pendingServerName.empty())
+				ctx += "-" + DemoRecorder::SanitizeComponent(g_pendingServerName);
+			return ctx;
+		}
+
 		void Client::LocalPlayerCreated() {
 			Player& p = world->GetLocalPlayer().value();
 
@@ -124,33 +145,9 @@ namespace spades {
 			std::string s = _Tr("Client", "You are connected with {0} ({2}) on {1}", verStr, osInfo, archInfo);
 			chatWindow->AddMessage(ChatWindow::ColoredMessage(s, MsgColorSysInfo));
 
-			// build demo filename context: gamemode-mapname-serveraddress
-			auto buildHostContext = [&]() -> std::string {
-				// game mode
-				std::string modeName = "game";
-				if (world) {
-					auto gmode = world->GetMode();
-					if (gmode) {
-						switch (gmode->ModeType()) {
-							case IGameMode::m_CTF: modeName = "ctf"; break;
-							case IGameMode::m_TC: modeName = "tc"; break;
-						}
-					}
-				}
-				if (net && net->GetGameProperties()->isGameModeArena)
-					modeName = "arena";
-
-				std::string ctx = modeName;
-				if (!g_pendingMapName.empty())
-					ctx += "-" + DemoRecorder::SanitizeComponent(g_pendingMapName);
-				if (!g_pendingServerName.empty())
-					ctx += "-" + DemoRecorder::SanitizeComponent(g_pendingServerName);
-				return ctx;
-			};
-
 			// start recording if auto-record is enabled
 			if (net && (int)cg_autoRecord != 0) {
-				if (net->StartDemoRecording("", buildHostContext())) {
+				if (net->StartDemoRecording("", BuildDemoContext())) {
 					SPLog("Started auto-recording demo: %s", net->GetDemoFilename().c_str());
 					int maxDemos = (int)cg_maxDemos;
 				if (maxDemos < 1)

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -42,14 +42,17 @@
 #include "GameMap.h"
 #include "World.h"
 
+#include "DemoRecorder.h"
 #include "NetClient.h"
 
 DEFINE_SPADES_SETTING(cg_corpseClearOnRespawn, "0");
 DEFINE_SPADES_SETTING(cg_centerMessage, "2");
 DEFINE_SPADES_SETTING(cg_autoScreenshot, "0");
+DEFINE_SPADES_SETTING(cg_autoRecord, "0");
 
 namespace spades {
 	extern std::string g_recordDemoPath;
+	extern bool g_autoRecordDemo;
 
 	namespace client {
 
@@ -120,12 +123,35 @@ namespace spades {
 			std::string s = _Tr("Client", "You are connected with {0} ({2}) on {1}", verStr, osInfo, archInfo);
 			chatWindow->AddMessage(ChatWindow::ColoredMessage(s, MsgColorSysInfo));
 
-			// start recording if --record was specified
-			if (!g_recordDemoPath.empty() && net) {
-				recordGameCount++;
-				std::string filename = g_recordDemoPath + "_" + std::to_string(recordGameCount) + ".dem";
-				if (net->StartDemoRecording(filename)) {
-					SPLog("Started recording demo: %s", net->GetDemoFilename().c_str());
+			// build sanitized hostname string for use in demo filenames
+			auto buildHostContext = [&]() -> std::string {
+				std::string host = hostname.ToString(false);
+				std::string ctx;
+				for (char c : host) {
+					if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))
+						ctx += c;
+					else
+						ctx += '_';
+					if (ctx.size() >= 32)
+						break;
+				}
+				return ctx;
+			};
+
+			// start recording if --record was specified, or auto-record is enabled
+			if (net) {
+				const bool doAutoRecord = g_autoRecordDemo || (int)cg_autoRecord != 0;
+				if (!g_recordDemoPath.empty()) {
+					recordGameCount++;
+					std::string filename = g_recordDemoPath + "_" + std::to_string(recordGameCount) + ".dem";
+					if (net->StartDemoRecording(filename)) {
+						SPLog("Started recording demo: %s", net->GetDemoFilename().c_str());
+					}
+				} else if (doAutoRecord) {
+					if (net->StartDemoRecording("", buildHostContext())) {
+						SPLog("Started auto-recording demo: %s", net->GetDemoFilename().c_str());
+						DemoRecorder::PruneOldRecordings(10);
+					}
 				}
 			}
 		}

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -50,6 +50,7 @@ DEFINE_SPADES_SETTING(cg_centerMessage, "2");
 DEFINE_SPADES_SETTING(cg_autoScreenshot, "0");
 DEFINE_SPADES_SETTING(cg_autoRecord, "0");
 DEFINE_SPADES_SETTING(cg_maxDemos, "10");
+DEFINE_SPADES_SETTING(cg_autoPruneDemos, "1");
 
 namespace spades {
 	extern std::string g_pendingMapName;
@@ -153,10 +154,11 @@ namespace spades {
 			if (net && (int)cg_autoRecord != 0) {
 				if (net->StartDemoRecording("", BuildDemoContext())) {
 					SPLog("Started auto-recording demo: %s", net->GetDemoFilename().c_str());
-					int maxDemos = (int)cg_maxDemos;
-				if (maxDemos < 1)
-					maxDemos = 1;
-				DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
+					if ((int)cg_autoPruneDemos != 0) {
+						int maxDemos = (int)cg_maxDemos;
+						if (maxDemos >= 1)
+							DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
+					}
 				}
 			}
 		}

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -48,9 +48,9 @@
 DEFINE_SPADES_SETTING(cg_corpseClearOnRespawn, "0");
 DEFINE_SPADES_SETTING(cg_centerMessage, "2");
 DEFINE_SPADES_SETTING(cg_autoScreenshot, "0");
-DEFINE_SPADES_SETTING(cg_autoRecord, "0");
-DEFINE_SPADES_SETTING(cg_maxDemos, "10");
-DEFINE_SPADES_SETTING(cg_autoPruneDemos, "1");
+DEFINE_SPADES_SETTING(cg_demoAutoRecord, "0");
+DEFINE_SPADES_SETTING(cg_demoMaxFiles, "10");
+DEFINE_SPADES_SETTING(cg_demoAutoPrune, "1");
 
 namespace spades {
 	extern std::string g_pendingMapName;
@@ -151,11 +151,11 @@ namespace spades {
 			chatWindow->AddMessage(ChatWindow::ColoredMessage(s, MsgColorSysInfo));
 
 			// start recording if auto-record is enabled
-			if (net && (int)cg_autoRecord != 0) {
+			if (net && (int)cg_demoAutoRecord != 0) {
 				if (net->StartDemoRecording("", BuildDemoContext())) {
 					SPLog("Started auto-recording demo: %s", net->GetDemoFilename().c_str());
-					if ((int)cg_autoPruneDemos != 0) {
-						int maxDemos = (int)cg_maxDemos;
+					if ((int)cg_demoAutoPrune != 0) {
+						int maxDemos = (int)cg_demoMaxFiles;
 						if (maxDemos >= 1)
 							DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
 					}

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -137,8 +137,9 @@ namespace spades {
 			followAndFreeCameraState.yaw = DEG2RAD(90);
 			followAndFreeCameraState.pitch = DEG2RAD(89);
 
-			// welcome players
-			centerMessageView->AddMessage(_Tr("Client", "Welcome to the server, {0}!", playerName));
+			// welcome players (skip during demo playback)
+			if (!IsDemoMode())
+				centerMessageView->AddMessage(_Tr("Client", "Welcome to the server, {0}!", playerName));
 
 			// play intro sound
 			Handle<IAudioChunk> c = audioDevice->RegisterSound("Sounds/Feedback/Intro.opus");

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -49,6 +49,7 @@ DEFINE_SPADES_SETTING(cg_corpseClearOnRespawn, "0");
 DEFINE_SPADES_SETTING(cg_centerMessage, "2");
 DEFINE_SPADES_SETTING(cg_autoScreenshot, "0");
 DEFINE_SPADES_SETTING(cg_autoRecord, "0");
+DEFINE_SPADES_SETTING(cg_maxDemos, "10");
 
 namespace spades {
 	extern std::string g_pendingMapName;
@@ -151,7 +152,10 @@ namespace spades {
 			if (net && (int)cg_autoRecord != 0) {
 				if (net->StartDemoRecording("", buildHostContext())) {
 					SPLog("Started auto-recording demo: %s", net->GetDemoFilename().c_str());
-					DemoRecorder::PruneOldRecordings(10);
+					int maxDemos = (int)cg_maxDemos;
+				if (maxDemos < 1)
+					maxDemos = 1;
+				DemoRecorder::PruneOldRecordings(static_cast<size_t>(maxDemos));
 				}
 			}
 		}

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -156,6 +156,7 @@ namespace spades {
 			if (net && (int)cg_demoAutoRecord != 0) {
 				if (net->StartDemoRecording("", BuildDemoContext())) {
 					SPLog("Started auto-recording demo: %s", net->GetDemoFilename().c_str());
+					ShowAlert(_Tr("Client", "Recording demo"), AlertType::Notice);
 					if ((int)cg_demoAutoPrune != 0) {
 						int maxDemos = (int)cg_demoMaxFiles;
 						if (maxDemos >= 1)

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -71,7 +71,8 @@ namespace spades {
 					}
 				}
 			}
-			if (net && net->GetGameProperties()->isGameModeArena)
+			if (activeNet && activeNet->GetStatus() == NetClientStatusConnected &&
+			    activeNet->GetGameProperties()->isGameModeArena)
 				modeName = "arena";
 
 			// Field order: server-map-gamemode
@@ -421,13 +422,8 @@ namespace spades {
 		}
 
 		void Client::PlayerSpawned(Player& p) {
-			// In demo mode, net is null - use demoNet's properties instead
-			bool isArena = false;
-			if (net) {
-				isArena = net->GetGameProperties()->isGameModeArena;
-			} else if (demoNet) {
-				isArena = demoNet->GetGameProperties()->isGameModeArena;
-			}
+			bool isArena = activeNet && activeNet->GetStatus() == NetClientStatusConnected &&
+			               activeNet->GetGameProperties()->isGameModeArena;
 			if (isArena || cg_corpseClearOnRespawn)
 				RemoveCorpseForPlayer(p.GetId());
 		}

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -49,6 +49,8 @@ DEFINE_SPADES_SETTING(cg_centerMessage, "2");
 DEFINE_SPADES_SETTING(cg_autoScreenshot, "0");
 
 namespace spades {
+	extern std::string g_recordDemoPath;
+
 	namespace client {
 
 #pragma mark - Server Packet Handlers
@@ -87,14 +89,19 @@ namespace spades {
 			followCameraState.enabled = false;
 
 			// get highest solid block at map's center
-			IntVector3 mapPos;
-			mapPos.x = map->Width() / 2;
-			mapPos.y = map->Height() / 2;
-			mapPos.z = map->GetTop(mapPos.x, mapPos.y) - map->Depth();
+			if (map) {
+				IntVector3 mapPos;
+				mapPos.x = map->Width() / 2;
+				mapPos.y = map->Height() / 2;
+				mapPos.z = map->GetTop(mapPos.x, mapPos.y) - map->Depth();
 
-			freeCameraState.position.x = static_cast<float>(mapPos.x);
-			freeCameraState.position.y = static_cast<float>(mapPos.y);
-			freeCameraState.position.z = static_cast<float>(mapPos.z);
+				freeCameraState.position.x = static_cast<float>(mapPos.x);
+				freeCameraState.position.y = static_cast<float>(mapPos.y);
+				freeCameraState.position.z = static_cast<float>(mapPos.z);
+			} else {
+				// Map not loaded yet, use default position
+				freeCameraState.position = MakeVector3(256.0F, 256.0F, 5.0F);
+			}
 			freeCameraState.velocity = MakeVector3(0, 0, 0);
 			followAndFreeCameraState.yaw = DEG2RAD(90);
 			followAndFreeCameraState.pitch = DEG2RAD(89);
@@ -112,6 +119,15 @@ namespace spades {
 			std::string archInfo = VersionInfo::GetAppArchitecture();
 			std::string s = _Tr("Client", "You are connected with {0} ({2}) on {1}", verStr, osInfo, archInfo);
 			chatWindow->AddMessage(ChatWindow::ColoredMessage(s, MsgColorSysInfo));
+
+			// start recording if --record was specified
+			if (!g_recordDemoPath.empty() && net) {
+				recordGameCount++;
+				std::string filename = g_recordDemoPath + "_" + std::to_string(recordGameCount) + ".dem";
+				if (net->StartDemoRecording(filename)) {
+					SPLog("Started recording demo: %s", net->GetDemoFilename().c_str());
+				}
+			}
 		}
 
 		void Client::TeamCapturedTerritory(int teamId, int terId) {
@@ -372,7 +388,14 @@ namespace spades {
 		}
 
 		void Client::PlayerSpawned(Player& p) {
-			if (net->GetGameProperties()->isGameModeArena || cg_corpseClearOnRespawn)
+			// In demo mode, net is null - use demoNet's properties instead
+			bool isArena = false;
+			if (net) {
+				isArena = net->GetGameProperties()->isGameModeArena;
+			} else if (demoNet) {
+				isArena = demoNet->GetGameProperties()->isGameModeArena;
+			}
+			if (isArena || cg_corpseClearOnRespawn)
 				RemoveCorpseForPlayer(p.GetId());
 		}
 

--- a/Sources/Client/Client_Scene.cpp
+++ b/Sources/Client/Client_Scene.cpp
@@ -69,7 +69,7 @@ namespace spades {
 			stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
 			if (!maybePlayer) {
 				// No local player - demo mode or not joined
-				if (isDemoMode) {
+				if (IsDemoMode()) {
 					// In demo mode, check if we're following a player
 					if (followCameraState.enabled) {
 						auto followedPlayer = world->GetPlayer(followedPlayerId);
@@ -89,7 +89,7 @@ namespace spades {
 			Player& p = maybePlayer.value();
 
 			bool localPlayerIsSpectating = p.IsSpectator() || staffSpectating;
-			bool isStaff = net ? net->GetGameProperties()->isStaff : false;
+			bool isStaff = activeNet->GetGameProperties()->isStaff;
 
 			if (!localPlayerIsSpectating && p.IsAlive()) {
 				// There exists an alive (non-spectator) local player
@@ -123,7 +123,7 @@ namespace spades {
 				case ClientCameraMode::Free:
 					SPAssert(world);
 					// In demo mode, there's no local player - use followed player or recorded player
-					if (isDemoMode) {
+					if (IsDemoMode()) {
 						if (followedPlayerId >= 0 && world->GetPlayer(followedPlayerId))
 							return followedPlayerId;
 						if (demoNet)

--- a/Sources/Client/Client_Scene.cpp
+++ b/Sources/Client/Client_Scene.cpp
@@ -68,9 +68,21 @@ namespace spades {
 				return ClientCameraMode::None;
 			stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
 			if (!maybePlayer) {
-				// In demo mode, use free camera (spectator) instead of NotJoined
-				if (isDemoMode)
+				// No local player - demo mode or not joined
+				if (isDemoMode) {
+					// In demo mode, check if we're following a player
+					if (followCameraState.enabled) {
+						auto followedPlayer = world->GetPlayer(followedPlayerId);
+						if (followedPlayer) {
+							bool isAlive = followedPlayer->IsAlive();
+							if (followCameraState.firstPerson && isAlive)
+								return ClientCameraMode::FirstPersonFollow;
+							else
+								return ClientCameraMode::ThirdPersonFollow;
+						}
+					}
 					return ClientCameraMode::Free;
+				}
 				return ClientCameraMode::NotJoined;
 			}
 
@@ -87,7 +99,8 @@ namespace spades {
 			} else {
 				// The local player is dead or a spectator
 				if (followCameraState.enabled) {
-					bool isAlive = world->GetPlayer(followedPlayerId)->IsAlive();
+					auto followedPlayer = world->GetPlayer(followedPlayerId);
+					bool isAlive = followedPlayer && followedPlayer->IsAlive();
 					if (followCameraState.firstPerson && isAlive)
 						return ClientCameraMode::FirstPersonFollow;
 					else
@@ -108,6 +121,16 @@ namespace spades {
 				case ClientCameraMode::None: SPUnreachable();
 				case ClientCameraMode::NotJoined:
 				case ClientCameraMode::Free:
+					SPAssert(world);
+					// In demo mode, there's no local player - use followed player or recorded player
+					if (isDemoMode) {
+						if (followedPlayerId >= 0 && world->GetPlayer(followedPlayerId))
+							return followedPlayerId;
+						if (demoNet)
+							return demoNet->GetRecordedLocalPlayerId();
+						return 0;
+					}
+					return world->GetLocalPlayerIndex().value();
 				case ClientCameraMode::FirstPersonLocal:
 				case ClientCameraMode::ThirdPersonLocal:
 					SPAssert(world);

--- a/Sources/Client/Client_Update.cpp
+++ b/Sources/Client/Client_Update.cpp
@@ -163,7 +163,8 @@ namespace spades {
 			if (!p)
 				return;
 			p->SetHeldBlockColor(color);
-			net->SendHeldBlockColor();
+			if (!isDemoMode)
+				net->SendHeldBlockColor();
 		}
 
 		/** Captures the color of the block player is looking at. */
@@ -187,7 +188,8 @@ namespace spades {
 			}
 
 			p.SetHeldBlockColor(col);
-			net->SendHeldBlockColor();
+			if (!isDemoMode)
+				net->SendHeldBlockColor();
 		}
 
 		void Client::SetSelectedTool(Player::ToolType type, bool quiet) {
@@ -299,73 +301,81 @@ namespace spades {
 				int score = player.GetScore();
 				if (score != lastScore)
 					lastScore = score;
+			} else if (isDemoMode) {
+				// In demo mode with no local player, still update spectator camera
+				UpdateLocalSpectator(dt);
 			}
 
+			// Check if demo is paused - freeze game objects but allow camera movement
+			bool demoPaused = isDemoMode && demoNet && demoNet->IsPaused();
+
+			if (!demoPaused) {
 #if 0
-			// dynamic time step
-			// physics diverges from server
-			world->Advance(dt);
+				// dynamic time step
+				// physics diverges from server
+				world->Advance(dt);
 #else
-			// accurately resembles server's physics
-			// but not smooth
-			if (dt > 0.0F) {
-				worldSubFrame += dt;
-				worldSubFrameFast += dt;
-			}
+				// accurately resembles server's physics
+				// but not smooth
+				if (dt > 0.0F) {
+					worldSubFrame += dt;
+					worldSubFrameFast += dt;
+				}
 
-			// these run at exactly ~60fps
-			float frameStep = 1.0F / 60.0F;
-			while (worldSubFrame >= frameStep) {
-				world->Advance(frameStep); // physics update
-				worldSubFrame -= frameStep;
-			}
+				// these run at exactly ~60fps
+				float frameStep = 1.0F / 60.0F;
+				while (worldSubFrame >= frameStep) {
+					world->Advance(frameStep); // physics update
+					worldSubFrame -= frameStep;
+				}
 
-			// these run at min. ~60fps but as fast as possible
-			float step = std::min(dt, frameStep);
-			while (worldSubFrameFast >= step) {
-				world->UpdatePlayer(step, false); // smooth orientation update
-				worldSubFrameFast -= step;
-			}
+				// these run at min. ~60fps but as fast as possible
+				float step = std::min(dt, frameStep);
+				while (worldSubFrameFast >= step) {
+					world->UpdatePlayer(step, false); // smooth orientation update
+					worldSubFrameFast -= step;
+				}
 #endif
 
-			// update player view (doesn't affect physics/game logics)
-			for (const auto& clientPlayer : clientPlayers) {
-				if (clientPlayer)
-					clientPlayer->Update(dt);
-			}
+				// update player view (doesn't affect physics/game logics)
+				for (const auto& clientPlayer : clientPlayers) {
+					if (clientPlayer)
+						clientPlayer->Update(dt);
+				}
 
-			// corpse never accesses audio nor renderer, so
-			// we can do it in the separate thread
-			class CorpseUpdateDispatch : public ConcurrentDispatch {
-				Client& client;
-				float dt;
+				// corpse never accesses audio nor renderer, so
+				// we can do it in the separate thread
+				class CorpseUpdateDispatch : public ConcurrentDispatch {
+					Client& client;
+					float dt;
 
-			public:
-				CorpseUpdateDispatch(Client& c, float dt) : client{c}, dt{dt} {}
-				void Run() override {
-					for (const auto& c : client.corpses) {
-						for (int i = 0; i < 4; i++)
-							c->Update(dt / 4.0F);
+				public:
+					CorpseUpdateDispatch(Client& c, float dt) : client{c}, dt{dt} {}
+					void Run() override {
+						for (const auto& c : client.corpses) {
+							for (int i = 0; i < 4; i++)
+								c->Update(dt / 4.0F);
+						}
 					}
-				}
-			};
-			CorpseUpdateDispatch corpseDispatch{*this, dt};
-			corpseDispatch.Start();
+				};
+				CorpseUpdateDispatch corpseDispatch{*this, dt};
+				corpseDispatch.Start();
 
-			// local entities should be done in the client thread
-			{
-				decltype(localEntities)::iterator it;
-				std::vector<decltype(it)> its;
-				for (it = localEntities.begin(); it != localEntities.end(); it++) {
-					if (!(*it)->Update(dt))
-						its.push_back(it);
+				// local entities should be done in the client thread
+				{
+					decltype(localEntities)::iterator it;
+					std::vector<decltype(it)> its;
+					for (it = localEntities.begin(); it != localEntities.end(); it++) {
+						if (!(*it)->Update(dt))
+							its.push_back(it);
+					}
+					for (const auto& it : its)
+						localEntities.erase(it);
 				}
-				for (const auto& it : its)
-					localEntities.erase(it);
+
+				bloodMarks->Update(dt);
+				corpseDispatch.Join();
 			}
-
-			bloodMarks->Update(dt);
-			corpseDispatch.Join();
 
 			if (grenadeVibration > 0.0F) {
 				grenadeVibration -= dt;
@@ -583,7 +593,7 @@ namespace spades {
 			inp.crouch = actualInput.crouch;
 
 			// send player input
-			{
+			if (!isDemoMode) {
 				PlayerInput sentInput = inp;
 				WeaponInput sentWeaponInput = winp;
 
@@ -597,7 +607,8 @@ namespace spades {
 				if (winp.secondary && !isWeaponShotgun) {
 					winp.secondary = false;
 					player.SetWeaponInput(winp);
-					net->SendWeaponInput(winp);
+					if (!isDemoMode)
+						net->SendWeaponInput(winp);
 					actualWeapInput = winp;
 					// do not overwrite input so zoom resumes automatically
 					if (!cg_holdAimDownSight)
@@ -605,7 +616,8 @@ namespace spades {
 				}
 
 				weapon.Reload();
-				net->SendReload();
+				if (!isDemoMode)
+					net->SendReload();
 			}
 
 			// is the selected tool no longer usable (ex. out of ammo)?
@@ -614,7 +626,8 @@ namespace spades {
 				winp.primary = false;
 				winp.secondary = false;
 				player.SetWeaponInput(winp);
-				net->SendWeaponInput(winp);
+				if (!isDemoMode)
+					net->SendWeaponInput(winp);
 				actualWeapInput = weapInput = winp;
 
 				// select another tool
@@ -631,8 +644,8 @@ namespace spades {
 			}
 
 			// send position/orientaion updates
-			{
-				float POSITION_UPDATE_RATE = 1.0F;			   // 1/s
+			if (!isDemoMode) {
+				float POSITION_UPDATE_RATE = 1.0F;             // 1/s
 				float ORIENTATION_UPDATE_RATE = 1.0F / 120.0F; // 120/s
 
 				Vector3 curPos = player.GetPosition();
@@ -833,7 +846,7 @@ namespace spades {
 			stmp::optional<const Grenade&> g) {
 			SPADES_MARK_FUNCTION();
 
-			if (g && p.IsLocalPlayer())
+			if (g && p.IsLocalPlayer() && !isDemoMode)
 				net->SendGrenade(*g);
 
 			if (!IsMuted()) {
@@ -1269,7 +1282,8 @@ namespace spades {
 			}
 
 			if (byLocalPlayer) {
-				net->SendHit(hurtPlayer.GetId(), type);
+				if (!isDemoMode)
+					net->SendHit(hurtPlayer.GetId(), type);
 
 				// register bullet hits
 				if (!isMeleeHit)
@@ -1589,11 +1603,13 @@ namespace spades {
 
 		void Client::LocalPlayerBlockAction(spades::IntVector3 v, BlockActionType type) {
 			SPADES_MARK_FUNCTION();
-			net->SendBlockAction(v, type);
+			if (!isDemoMode)
+				net->SendBlockAction(v, type);
 		}
 		void Client::LocalPlayerCreatedLineBlock(spades::IntVector3 v1, spades::IntVector3 v2) {
 			SPADES_MARK_FUNCTION();
-			net->SendBlockLine(v1, v2);
+			if (!isDemoMode)
+				net->SendBlockLine(v1, v2);
 		}
 
 		void Client::LocalPlayerHurt(HurtType type, spades::Vector3 source) {

--- a/Sources/Client/Client_Update.cpp
+++ b/Sources/Client/Client_Update.cpp
@@ -163,8 +163,7 @@ namespace spades {
 			if (!p)
 				return;
 			p->SetHeldBlockColor(color);
-			if (!isDemoMode)
-				net->SendHeldBlockColor();
+			activeNet->SendHeldBlockColor();
 		}
 
 		/** Captures the color of the block player is looking at. */
@@ -188,8 +187,7 @@ namespace spades {
 			}
 
 			p.SetHeldBlockColor(col);
-			if (!isDemoMode)
-				net->SendHeldBlockColor();
+			activeNet->SendHeldBlockColor();
 		}
 
 		void Client::SetSelectedTool(Player::ToolType type, bool quiet) {
@@ -301,13 +299,13 @@ namespace spades {
 				int score = player.GetScore();
 				if (score != lastScore)
 					lastScore = score;
-			} else if (isDemoMode) {
+			} else if (IsDemoMode()) {
 				// In demo mode with no local player, still update spectator camera
 				UpdateLocalSpectator(dt);
 			}
 
 			// Check if demo is paused - freeze game objects but allow camera movement
-			bool demoPaused = isDemoMode && demoNet && demoNet->IsPaused();
+			bool demoPaused = IsDemoMode() && demoNet && demoNet->IsPaused();
 
 			if (!demoPaused) {
 #if 0
@@ -593,12 +591,12 @@ namespace spades {
 			inp.crouch = actualInput.crouch;
 
 			// send player input
-			if (!isDemoMode) {
+			{
 				PlayerInput sentInput = inp;
 				WeaponInput sentWeaponInput = winp;
 
-				net->SendPlayerInput(sentInput);
-				net->SendWeaponInput(sentWeaponInput);
+				activeNet->SendPlayerInput(sentInput);
+				activeNet->SendWeaponInput(sentWeaponInput);
 			}
 
 			// send weapon reload
@@ -607,8 +605,7 @@ namespace spades {
 				if (winp.secondary && !isWeaponShotgun) {
 					winp.secondary = false;
 					player.SetWeaponInput(winp);
-					if (!isDemoMode)
-						net->SendWeaponInput(winp);
+					activeNet->SendWeaponInput(winp);
 					actualWeapInput = winp;
 					// do not overwrite input so zoom resumes automatically
 					if (!cg_holdAimDownSight)
@@ -616,8 +613,7 @@ namespace spades {
 				}
 
 				weapon.Reload();
-				if (!isDemoMode)
-					net->SendReload();
+				activeNet->SendReload();
 			}
 
 			// is the selected tool no longer usable (ex. out of ammo)?
@@ -626,8 +622,7 @@ namespace spades {
 				winp.primary = false;
 				winp.secondary = false;
 				player.SetWeaponInput(winp);
-				if (!isDemoMode)
-					net->SendWeaponInput(winp);
+				activeNet->SendWeaponInput(winp);
 				actualWeapInput = weapInput = winp;
 
 				// select another tool
@@ -644,7 +639,7 @@ namespace spades {
 			}
 
 			// send position/orientaion updates
-			if (!isDemoMode) {
+			{
 				float POSITION_UPDATE_RATE = 1.0F;             // 1/s
 				float ORIENTATION_UPDATE_RATE = 1.0F / 120.0F; // 120/s
 
@@ -653,7 +648,7 @@ namespace spades {
 					&& time - lastPosSentTime > POSITION_UPDATE_RATE) {
 					lastPosSentTime = time;
 					lastPosSent = curPos;
-					net->SendPosition(curPos);
+					activeNet->SendPosition(curPos);
 				}
 
 				Vector3 curFront = player.GetFront();
@@ -661,7 +656,7 @@ namespace spades {
 					&& time - lastOriSentTime > ORIENTATION_UPDATE_RATE) {
 					lastOriSentTime = time;
 					lastFrontSent = curFront;
-					net->SendOrientation(curFront);
+					activeNet->SendOrientation(curFront);
 				}
 			}
 
@@ -846,8 +841,8 @@ namespace spades {
 			stmp::optional<const Grenade&> g) {
 			SPADES_MARK_FUNCTION();
 
-			if (g && p.IsLocalPlayer() && !isDemoMode)
-				net->SendGrenade(*g);
+			if (g && p.IsLocalPlayer())
+				activeNet->SendGrenade(*g);
 
 			if (!IsMuted()) {
 				Handle<IAudioChunk> c =
@@ -1282,8 +1277,7 @@ namespace spades {
 			}
 
 			if (byLocalPlayer) {
-				if (!isDemoMode)
-					net->SendHit(hurtPlayer.GetId(), type);
+				activeNet->SendHit(hurtPlayer.GetId(), type);
 
 				// register bullet hits
 				if (!isMeleeHit)
@@ -1603,13 +1597,11 @@ namespace spades {
 
 		void Client::LocalPlayerBlockAction(spades::IntVector3 v, BlockActionType type) {
 			SPADES_MARK_FUNCTION();
-			if (!isDemoMode)
-				net->SendBlockAction(v, type);
+			activeNet->SendBlockAction(v, type);
 		}
 		void Client::LocalPlayerCreatedLineBlock(spades::IntVector3 v1, spades::IntVector3 v2) {
 			SPADES_MARK_FUNCTION();
-			if (!isDemoMode)
-				net->SendBlockLine(v1, v2);
+			activeNet->SendBlockLine(v1, v2);
 		}
 
 		void Client::LocalPlayerHurt(HurtType type, spades::Vector3 source) {

--- a/Sources/Client/Client_Update.cpp
+++ b/Sources/Client/Client_Update.cpp
@@ -208,7 +208,7 @@ namespace spades {
 
 #pragma mark - World Update
 
-		void Client::UpdateWorld(float dt) {
+		void Client::UpdateWorld(float dt, float gameplayDt) {
 			SPADES_MARK_FUNCTION();
 
 			stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
@@ -317,9 +317,9 @@ namespace spades {
 #else
 				// accurately resembles server's physics
 				// but not smooth
-				if (dt > 0.0F) {
-					worldSubFrame += dt;
-					worldSubFrameFast += dt;
+				if (gameplayDt > 0.0F) {
+					worldSubFrame += gameplayDt;
+					worldSubFrameFast += gameplayDt;
 				}
 
 				// these run at exactly ~60fps
@@ -330,7 +330,7 @@ namespace spades {
 				}
 
 				// these run at min. ~60fps but as fast as possible
-				float step = std::min(dt, frameStep);
+				float step = std::min(gameplayDt, frameStep);
 				while (worldSubFrameFast >= step) {
 					world->UpdatePlayer(step, false); // smooth orientation update
 					worldSubFrameFast -= step;
@@ -340,7 +340,7 @@ namespace spades {
 				// update player view (doesn't affect physics/game logics)
 				for (const auto& clientPlayer : clientPlayers) {
 					if (clientPlayer)
-						clientPlayer->Update(dt);
+						clientPlayer->Update(gameplayDt);
 				}
 
 				// corpse never accesses audio nor renderer, so
@@ -358,7 +358,7 @@ namespace spades {
 						}
 					}
 				};
-				CorpseUpdateDispatch corpseDispatch{*this, dt};
+				CorpseUpdateDispatch corpseDispatch{*this, gameplayDt};
 				corpseDispatch.Start();
 
 				// local entities should be done in the client thread
@@ -366,14 +366,14 @@ namespace spades {
 					decltype(localEntities)::iterator it;
 					std::vector<decltype(it)> its;
 					for (it = localEntities.begin(); it != localEntities.end(); it++) {
-						if (!(*it)->Update(dt))
+						if (!(*it)->Update(gameplayDt))
 							its.push_back(it);
 					}
 					for (const auto& it : its)
 						localEntities.erase(it);
 				}
 
-				bloodMarks->Update(dt);
+				bloodMarks->Update(gameplayDt);
 				corpseDispatch.Join();
 			}
 

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -419,7 +419,8 @@ namespace spades {
 
 						if (GetWorld()) {
 							auto p = GetWorld()->GetPlayer(idx);
-							if (p && p != GetWorld()->GetLocalPlayer()
+							auto localPlayer = GetLocalPlayerOrNull();
+							if (p && (!localPlayer || &*p != &*localPlayer)
 								&& p->IsAlive() && !p->IsSpectator()) {
 								p->RepositionPlayer(pos);
 								p->SetOrientation(front);

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -193,7 +193,7 @@ namespace spades {
 						HandleGamePacket(reader);
 					} else {
 						// Save packet for later processing
-						savedPackets.push_back(reader.GetData());
+						preMapPackets.push_back(reader.GetData());
 					}
 				} else if (status == NetClientStatusConnected) {
 					HandleGamePacket(reader);
@@ -869,19 +869,19 @@ namespace spades {
 
 			SPAssert(GetWorld());
 
-			SPLog("Processing %d saved demo packets...", (int)savedPackets.size());
+			SPLog("Processing %d saved demo packets...", (int)preMapPackets.size());
 
 			std::fill(savedPlayerTeam.begin(), savedPlayerTeam.end(), -1);
 
 			try {
-				for (const auto& packets : savedPackets) {
+				for (const auto& packets : preMapPackets) {
 					NetPacketReader r(packets);
 					HandleGamePacket(r);
 				}
-				savedPackets.clear();
+				preMapPackets.clear();
 				SPLog("Demo packets processed.");
 			} catch (...) {
-				savedPackets.clear();
+				preMapPackets.clear();
 				throw;
 			}
 

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -385,13 +385,15 @@ namespace spades {
 
 			switch (packetType) {
 				case PacketTypePositionData: {
-					auto p = GetLocalPlayerOrNull();
-					if (!p) break;
 					if (r.GetLength() != 13) break;
+					if (recordedLocalPlayerId < 0) break;
+					auto p = GetPlayerOrNull(recordedLocalPlayerId);
+					if (!p) break;
 					p->RepositionPlayer(r.ReadVector3());
 				} break;
 				case PacketTypeOrientationData: {
-					auto p = GetLocalPlayerOrNull();
+					if (recordedLocalPlayerId < 0) break;
+					auto p = GetPlayerOrNull(recordedLocalPlayerId);
 					if (!p) break;
 					Vector3 o = r.ReadVector3();
 					if (o.GetSquaredLength() < 0.01F) break;
@@ -459,7 +461,8 @@ namespace spades {
 					}
 					break;
 				case PacketTypeSetHP: {
-					auto p = GetLocalPlayerOrNull();
+					if (recordedLocalPlayerId < 0) break;
+					auto p = GetPlayerOrNull(recordedLocalPlayerId);
 					if (!p) break;
 					int hp = r.ReadByte();
 					int type = r.ReadByte();
@@ -905,8 +908,10 @@ namespace spades {
 				} break;
 				case PacketTypeRestock: {
 					r.ReadByte();
-					auto p = GetLocalPlayerOrNull();
-					if (p) p->Restock();
+					if (recordedLocalPlayerId >= 0) {
+						auto p = GetPlayerOrNull(recordedLocalPlayerId);
+						if (p) p->Restock();
+					}
 				} break;
 				case PacketTypeFogColour: {
 					if (GetWorld()) {
@@ -915,15 +920,18 @@ namespace spades {
 					}
 				} break;
 				case PacketTypeWeaponReload: {
-					auto p = GetPlayerOrNull(r.ReadByte());
+					int pId = r.ReadByte();
+					auto p = GetPlayerOrNull(pId);
 					if (!p) break;
-					auto localPlayer = GetLocalPlayerOrNull();
-					if (&*p != localPlayer) {
-						p->Reload();
-					} else {
-						int clip = r.ReadByte();
-						int reserve = r.ReadByte();
+					int clip = r.ReadByte();
+					int reserve = r.ReadByte();
+					// For the recorded player, apply real ammo counts from external demos.
+					// Our own demos record the client-sent packet (zeros), so non-zero
+					// values reliably indicate a server-sent response.
+					if (pId == recordedLocalPlayerId && (clip != 0 || reserve != 0)) {
 						p->ReloadDone(clip, reserve);
+					} else {
+						p->Reload();
 					}
 				} break;
 				case PacketTypeChangeTeam:

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -84,7 +84,7 @@ namespace spades {
 
 
 		DemoNetClient::DemoNetClient(Client* c) : client(c), status(NetClientStatusNotConnected),
-		    protocolVersion(0), expectedMapSize(0), receivedMapBytes(0),
+		    expectedMapSize(0), receivedMapBytes(0),
 		    recordedLocalPlayerId(-1), seekingMode(false) {
 			SPADES_MARK_FUNCTION();
 
@@ -114,17 +114,15 @@ namespace spades {
 				return false;
 			}
 
-			protocolVersion = demoPlayer->GetProtocolVersion();
-
 			// Create game properties based on protocol version
-			ProtocolVersion protoVer = (protocolVersion == 4)
+			ProtocolVersion protoVer = (demoPlayer->GetProtocolVersion() == 4)
 				? ProtocolVersion::v076 : ProtocolVersion::v075;
 			properties.reset(new GameProperties(protoVer));
 
 			status = NetClientStatusConnecting;
 			statusString = _Tr("NetClient", "Loading demo");
 
-			SPLog("Opened demo: %s (protocol %d)", filename.c_str(), protocolVersion);
+			SPLog("Opened demo: %s (protocol %d)", filename.c_str(), demoPlayer->GetProtocolVersion());
 			return true;
 		}
 
@@ -268,7 +266,7 @@ namespace spades {
 				} break;
 				case PacketTypeWorldUpdate: {
 					int bytesPerEntry = 24;
-					if (protocolVersion == 4)
+					if (demoPlayer->GetProtocolVersion() == 4)
 						bytesPerEntry++;
 
 					if (!seekingMode)
@@ -277,7 +275,7 @@ namespace spades {
 					int entries = static_cast<int>(r.GetLength() / bytesPerEntry);
 					for (int i = 0; i < entries; i++) {
 						int idx = i;
-						if (protocolVersion == 4) {
+						if (demoPlayer->GetProtocolVersion() == 4) {
 							idx = r.ReadByte();
 							if (idx < 0 || idx >= properties->GetMaxNumPlayerSlots())
 								SPRaise("Invalid player ID %d in WorldUpdate", idx);

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -960,6 +960,11 @@ namespace spades {
 			statusString = _Tr("NetClient", "Playing demo");
 		}
 
+		void DemoNetClient::SeekPreview(float time) {
+			if (!demoPlayer) return;
+			demoPlayer->Seek(time);
+		}
+
 		void DemoNetClient::SeekToBeginning() {
 			if (!demoPlayer) return;
 

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -256,7 +256,7 @@ namespace spades {
 		};
 
 		DemoNetClient::DemoNetClient(Client* c) : client(c), status(NetClientStatusNotConnected),
-		    protocolVersion(0), lastFrameTime(0.0f), expectedMapSize(0), receivedMapBytes(0),
+		    protocolVersion(0), expectedMapSize(0), receivedMapBytes(0),
 		    recordedLocalPlayerId(-1), seekingMode(false) {
 			SPADES_MARK_FUNCTION();
 
@@ -305,8 +305,6 @@ namespace spades {
 
 			if (status == NetClientStatusNotConnected)
 				return;
-
-			lastFrameTime = dt;
 
 			// Process packets from the demo
 			demoPlayer->Update(dt, [this](const std::vector<char>& data) {

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -173,7 +173,7 @@ namespace spades {
 
 					int type = reader.GetType();
 					if (type == PacketTypeMapChunk) {
-						std::vector<char> dt = reader.GetData();
+						const std::vector<char>& dt = reader.GetData();
 						size_t chunkSize = dt.size() - 1;
 						receivedMapBytes += chunkSize;
 						mapLoader->AddRawChunk(dt.data() + 1, chunkSize);

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -1142,7 +1142,7 @@ namespace spades {
 		void DemoNetClient::SeekToBeginning() {
 			if (!demoPlayer) return;
 
-			if (initialMap) {
+			if (initialMap && demoPlayer->GetTime() > 0.0f) {
 				auto view = client->SaveViewState();
 				ResetWorldForReplay();
 				FastReplay(0.0f);

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -217,7 +217,7 @@ namespace spades {
 
 		DemoNetClient::DemoNetClient(Client* c) : client(c), status(NetClientStatusNotConnected),
 		    protocolVersion(0), lastFrameTime(0.0f), expectedMapSize(0), receivedMapBytes(0),
-		    recordedLocalPlayerId(-1) {
+		    recordedLocalPlayerId(-1), seekingMode(false) {
 			SPADES_MARK_FUNCTION();
 
 			demoPlayer.reset(new DemoPlayer());
@@ -405,7 +405,8 @@ namespace spades {
 					if (protocolVersion == 4)
 						bytesPerEntry++;
 
-					client->MarkWorldUpdate();
+					if (!seekingMode)
+						client->MarkWorldUpdate();
 
 					int entries = static_cast<int>(r.GetLength() / bytesPerEntry);
 					for (int i = 0; i < entries; i++) {
@@ -608,11 +609,13 @@ namespace spades {
 
 					// In demo mode, user is always spectator - track all team changes
 					if (savedPlayerTeam.at(pId) != team) {
-						client->PlayerJoinedTeam(pRef);
+						if (!seekingMode)
+							client->PlayerJoinedTeam(pRef);
 						savedPlayerTeam.at(pId) = team;
 					}
 
-					client->PlayerSpawned(pRef);
+					if (!seekingMode)
+						client->PlayerSpawned(pRef);
 				} break;
 				case PacketTypeBlockAction: {
 					stmp::optional<Player&> p = GetPlayerOrNull(r.ReadByte());
@@ -627,29 +630,33 @@ namespace spades {
 							GetWorld()->CreateBlock(pos, p->GetBlockColor());
 							if (!GetWorld()->GetMap()->IsSolidWrapped(pos.x, pos.y, pos.z)) {
 								p->UseBlocks(1);
-								if (p->IsLocalPlayer())
+								if (p->IsLocalPlayer() && !seekingMode)
 									client->RegisterPlacedBlocks(1);
 							}
-							client->PlayerCreatedBlock(*p);
+							if (!seekingMode)
+								client->PlayerCreatedBlock(*p);
 						}
 					} else if (action == BlockActionTool) {
 						cells.push_back(pos);
 						GetWorld()->DestroyBlock(cells);
 						if (p && p->IsToolSpade())
 							p->GotBlock();
-						client->PlayerDestroyedBlockWithWeaponOrTool(pos);
+						if (!seekingMode)
+							client->PlayerDestroyedBlockWithWeaponOrTool(pos);
 					} else if (action == BlockActionDig) {
 						for (int z = -1; z <= 1; z++)
 							cells.push_back(MakeIntVector3(pos.x, pos.y, pos.z + z));
 						GetWorld()->DestroyBlock(cells);
-						client->PlayerDiggedBlock(pos);
+						if (!seekingMode)
+							client->PlayerDiggedBlock(pos);
 					} else if (action == BlockActionGrenade) {
 						for (int x = -1; x <= 1; x++)
 						for (int y = -1; y <= 1; y++)
 						for (int z = -1; z <= 1; z++)
 							cells.push_back(MakeIntVector3(pos.x + x, pos.y + y, pos.z + z));
 						GetWorld()->DestroyBlock(cells);
-						client->GrenadeDestroyedBlock(pos);
+						if (!seekingMode)
+							client->GrenadeDestroyedBlock(pos);
 					}
 				} break;
 				case PacketTypeBlockLine: {
@@ -658,6 +665,7 @@ namespace spades {
 					IntVector3 pos2 = r.ReadIntVector3();
 
 					auto cells = GetWorld()->CubeLine(pos1, pos2, 50);
+
 					for (const auto& c : cells) {
 						if (!GetWorld()->GetMap()->IsSolid(c.x, c.y, c.z))
 							GetWorld()->CreateBlock(c, p ? p->GetBlockColor() : temporaryPlayerBlockColor);
@@ -666,9 +674,10 @@ namespace spades {
 					if (p) {
 						int blocks = static_cast<int>(cells.size());
 						p->UseBlocks(blocks);
-						if (p->IsLocalPlayer())
+						if (p->IsLocalPlayer() && !seekingMode)
 							client->RegisterPlacedBlocks(blocks);
-						client->PlayerCreatedBlock(*p);
+						if (!seekingMode)
+							client->PlayerCreatedBlock(*p);
 					}
 				} break;
 				case PacketTypeStateData:
@@ -748,7 +757,8 @@ namespace spades {
 
 							GetWorld()->SetMode(std::move(tc));
 						}
-						client->JoinedGame();
+						if (!seekingMode)
+							client->JoinedGame();
 					}
 					break;
 				case PacketTypeKillAction: {
@@ -790,22 +800,24 @@ namespace spades {
 					int type = r.ReadByte();
 					std::string msg = TrimSpaces(r.ReadRemainingString());
 
-					if (type == 2) { // System
-						client->ServerSentMessage(false, msg);
-						properties->HandleServerMessage(msg);
-					} else if (type == 0 || type == 1) { // All or Team
-						stmp::optional<Player&> p = GetPlayerOrNull(playerId);
-						if (p) {
-							client->PlayerSentChatMessage(*p, (type == 0), msg);
-						} else {
-							client->ServerSentMessage((type == 1), msg);
+					if (!seekingMode) {
+						if (type == 2) { // System
+							client->ServerSentMessage(false, msg);
+							properties->HandleServerMessage(msg);
+						} else if (type == 0 || type == 1) { // All or Team
+							stmp::optional<Player&> p = GetPlayerOrNull(playerId);
+							if (p) {
+								client->PlayerSentChatMessage(*p, (type == 0), msg);
+							} else {
+								client->ServerSentMessage((type == 1), msg);
+							}
 						}
 					}
 				} break;
 				case PacketTypePlayerLeft: {
 					int pId = r.ReadByte();
 					auto p = GetPlayerOrNull(pId);
-					if (p)
+					if (p && !seekingMode)
 						client->PlayerLeaving(*p);
 					GetWorld()->GetPlayerPersistent(pId).score = 0;
 					if (pId >= 0 && pId < (int)savedPlayerTeam.size())
@@ -823,7 +835,8 @@ namespace spades {
 					auto& tc = dynamic_cast<TCGameMode&>(*mode);
 					if (territoryId >= tc.GetNumTerritories()) break;
 
-					client->TeamCapturedTerritory(state, territoryId);
+					if (!seekingMode)
+						client->TeamCapturedTerritory(state, territoryId);
 
 					TCGameMode::Territory& t = tc.GetTerritory(territoryId);
 					t.ownerTeamId = state;
@@ -832,7 +845,7 @@ namespace spades {
 					t.progressStartTime = 0.0F;
 					t.capturingTeamId = -1;
 
-					if (winning)
+					if (winning && !seekingMode)
 						client->TeamWon(state);
 				} break;
 				case PacketTypeProgressBar: {
@@ -869,12 +882,14 @@ namespace spades {
 					team.score++;
 					team.hasIntel = false;
 
-					client->PlayerCapturedIntel(*p);
+					if (!seekingMode)
+						client->PlayerCapturedIntel(*p);
 					GetWorld()->GetPlayerPersistent(pId).score += 10;
 
 					bool winning = r.ReadByte() != 0;
 					if (winning) {
-						client->TeamWon(teamId);
+						if (!seekingMode)
+							client->TeamWon(teamId);
 						ctf.ResetIntelHoldingStatus();
 					}
 				} break;
@@ -890,7 +905,8 @@ namespace spades {
 					CTFGameMode::Team& team = ctf.GetTeam(p->GetTeamId());
 					team.hasIntel = true;
 					team.carrierId = pId;
-					client->PlayerPickedIntel(*p);
+					if (!seekingMode)
+						client->PlayerPickedIntel(*p);
 				} break;
 				case PacketTypeIntelDrop: {
 					stmp::optional<IGameMode&> mode = GetWorld()->GetMode();
@@ -904,7 +920,8 @@ namespace spades {
 					auto& ctf = dynamic_cast<CTFGameMode&>(mode.value());
 					ctf.GetTeam(teamId).hasIntel = false;
 					ctf.GetTeam(1 - teamId).flagPos = r.ReadVector3();
-					client->PlayerDropIntel(*p);
+					if (!seekingMode)
+						client->PlayerDropIntel(*p);
 				} break;
 				case PacketTypeRestock: {
 					r.ReadByte();
@@ -1001,6 +1018,10 @@ namespace spades {
 				savedPackets.clear();
 				throw;
 			}
+
+			// Snapshot the map state at t=0 for backward seek support
+			initialMap = GetWorld()->GetMap()->Clone();
+			SPLog("Demo initial map snapshot saved.");
 		}
 
 		float DemoNetClient::GetMapReceivingProgress() {
@@ -1017,11 +1038,47 @@ namespace spades {
 			return statusString;
 		}
 
+		void DemoNetClient::ResetWorldForReplay() {
+			if (!initialMap) return;
+
+			// Rebuild the world with a fresh copy of the initial map
+			World* w = new World(properties);
+			w->SetMap(initialMap->Clone());
+			client->SetWorld(w);
+
+			// Reset all per-player tracking state
+			recordedLocalPlayerId = -1;
+			std::fill(savedPlayerTeam.begin(), savedPlayerTeam.end(), -1);
+			std::fill(savedPlayerPos.begin(), savedPlayerPos.end(), Vector3{});
+			std::fill(savedPlayerFront.begin(), savedPlayerFront.end(), Vector3{});
+		}
+
+		void DemoNetClient::FastReplay(float targetTime) {
+			seekingMode = true;
+			try {
+				size_t count = demoPlayer->GetPacketCount();
+				for (size_t i = 0; i < count; i++) {
+					if (demoPlayer->GetPacketTimestamp(i) > targetTime)
+						break;
+					ProcessPacket(demoPlayer->GetPacket(i));
+				}
+			} catch (...) {
+				seekingMode = false;
+				throw;
+			}
+			seekingMode = false;
+		}
+
 		void DemoNetClient::Seek(float time) {
 			if (!demoPlayer) return;
 
-			// Adjust playback time - note that seeking backward may result in
-			// inconsistent world state since packets won't be re-applied
+			if (time < demoPlayer->GetTime() && initialMap) {
+				auto view = client->SaveViewState();
+				ResetWorldForReplay();
+				FastReplay(time);
+				client->RestoreViewState(view);
+			}
+
 			demoPlayer->Seek(time);
 			statusString = _Tr("NetClient", "Playing demo");
 		}
@@ -1029,8 +1086,13 @@ namespace spades {
 		void DemoNetClient::SeekToBeginning() {
 			if (!demoPlayer) return;
 
-			// Seek to beginning of timeline without reloading the world
-			// Note: World state may be inconsistent, but allows video-player-like scrubbing
+			if (initialMap) {
+				auto view = client->SaveViewState();
+				ResetWorldForReplay();
+				FastReplay(0.0f);
+				client->RestoreViewState(view);
+			}
+
 			demoPlayer->Seek(0.0f);
 			demoPlayer->Resume();
 			statusString = _Tr("NetClient", "Playing demo");

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -931,12 +931,9 @@ namespace spades {
 			}
 
 			try {
-				size_t count = demoPlayer->GetPacketCount();
-				for (size_t i = 0; i < count; i++) {
-					if (demoPlayer->GetPacketTimestamp(i) > targetTime)
-						break;
-					ProcessPacket(demoPlayer->GetPacket(i));
-				}
+				demoPlayer->ReplayUpTo(targetTime, [this](const std::vector<char>& data) {
+					ProcessPacket(data);
+				});
 			} catch (...) {
 				if (GetWorld())
 					GetWorld()->SetListener(savedListener);

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -38,9 +38,49 @@
 #include <Core/Settings.h>
 #include <Core/Strings.h>
 #include <Core/TMPUtils.h>
+#include "IWorldListener.h"
 
 namespace spades {
 	namespace client {
+
+		namespace {
+			// World listener used during fast replay: forwards only PlayerObjectSet (which
+			// populates clientPlayers) and silently drops all sound/effect callbacks.
+			class SilentWorldListener : public IWorldListener {
+				Client* client;
+			public:
+				SilentWorldListener(Client* c) : client(c) {}
+				void PlayerObjectSet(int id) override { client->PlayerObjectSet(id); }
+				void PlayerMadeFootstep(Player&) override {}
+				void PlayerJumped(Player&) override {}
+				void PlayerLanded(Player&, bool) override {}
+				void PlayerFiredWeapon(Player&) override {}
+				void PlayerEjectedBrass(Player&) override {}
+				void PlayerDryFiredWeapon(Player&) override {}
+				void PlayerReloadingWeapon(Player&) override {}
+				void PlayerReloadedWeapon(Player&) override {}
+				void PlayerChangedTool(Player&) override {}
+				void PlayerPulledGrenadePin(Player&) override {}
+				void PlayerThrewGrenade(Player&, stmp::optional<const Grenade&>) override {}
+				void PlayerMissedSpade(Player&) override {}
+				void PlayerRestocked(Player&) override {}
+				void PlayerHitBlockWithSpade(Player&, Vector3, IntVector3, IntVector3) override {}
+				void PlayerKilledPlayer(Player&, Player&, KillType) override {}
+				void BulletHitPlayer(Player&, HitType, Vector3, Player&,
+				                     std::unique_ptr<IBulletHitScanState>&) override {}
+				void BulletNearPlayer(Player&) override {}
+				void BulletHitBlock(Vector3, IntVector3, IntVector3) override {}
+				void AddBulletTracer(Player&, Vector3, Vector3) override {}
+				void GrenadeExploded(const Grenade&) override {}
+				void GrenadeBounced(const Grenade&) override {}
+				void GrenadeDroppedIntoWater(const Grenade&) override {}
+				void BlocksFell(std::vector<IntVector3>) override {}
+				void LocalPlayerBlockAction(IntVector3, BlockActionType) override {}
+				void LocalPlayerCreatedLineBlock(IntVector3, IntVector3) override {}
+				void LocalPlayerHurt(HurtType, Vector3) override {}
+				void LocalPlayerBuildError(BuildFailureReason) override {}
+			};
+		} // anonymous namespace (SilentWorldListener)
 
 		namespace {
 			enum { BLUE_FLAG = 0, GREEN_FLAG = 1, BLUE_BASE = 2, GREEN_BASE = 3 };
@@ -1055,6 +1095,17 @@ namespace spades {
 
 		void DemoNetClient::FastReplay(float targetTime) {
 			seekingMode = true;
+
+			// Replace the world listener with a silent stub so that kill sounds,
+			// grenade effects, footsteps, etc. don't fire for every replayed packet.
+			// PlayerObjectSet is still forwarded so clientPlayers[] stays in sync.
+			SilentWorldListener silent(client);
+			IWorldListener* savedListener = nullptr;
+			if (GetWorld()) {
+				savedListener = GetWorld()->GetListener();
+				GetWorld()->SetListener(&silent);
+			}
+
 			try {
 				size_t count = demoPlayer->GetPacketCount();
 				for (size_t i = 0; i < count; i++) {
@@ -1063,9 +1114,14 @@ namespace spades {
 					ProcessPacket(demoPlayer->GetPacket(i));
 				}
 			} catch (...) {
+				if (GetWorld())
+					GetWorld()->SetListener(savedListener);
 				seekingMode = false;
 				throw;
 			}
+
+			if (GetWorld())
+				GetWorld()->SetListener(savedListener);
 			seekingMode = false;
 		}
 

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -949,7 +949,7 @@ namespace spades {
 		void DemoNetClient::Seek(float time) {
 			if (!demoPlayer) return;
 
-			if (time < demoPlayer->GetTime() && initialMap) {
+			if (initialMap) {
 				auto view = client->SaveViewState();
 				ResetWorldForReplay();
 				FastReplay(time);

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -90,7 +90,7 @@ namespace spades {
 
 			demoPlayer.reset(new DemoPlayer());
 
-			const int slots = 256;
+			const int slots = GameProperties::kMaxPlayerSlots;
 			savedPlayerPos.resize(slots);
 			savedPlayerFront.resize(slots);
 			savedPlayerTeam.resize(slots);

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -1,0 +1,1031 @@
+/*
+ Copyright (c) 2013 yvt
+ based on code of pysnip (c) Mathias Kaerlev 2011-2012.
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#include <cstring>
+
+#include "CTFGameMode.h"
+#include "Client.h"
+#include "DemoNetClient.h"
+#include "GameMap.h"
+#include "GameMapLoader.h"
+#include "GameProperties.h"
+#include "Grenade.h"
+#include "Player.h"
+#include "TCGameMode.h"
+#include "Weapon.h"
+#include "World.h"
+#include <Core/CP437.h>
+#include <Core/Debug.h>
+#include <Core/Exception.h>
+#include <Core/Settings.h>
+#include <Core/Strings.h>
+#include <Core/TMPUtils.h>
+
+namespace spades {
+	namespace client {
+
+		namespace {
+			enum { BLUE_FLAG = 0, GREEN_FLAG = 1, BLUE_BASE = 2, GREEN_BASE = 3 };
+			enum PacketType {
+				PacketTypePositionData = 0,
+				PacketTypeOrientationData = 1,
+				PacketTypeWorldUpdate = 2,
+				PacketTypeInputData = 3,
+				PacketTypeWeaponInput = 4,
+				PacketTypeSetHP = 5,
+				PacketTypeGrenadePacket = 6,
+				PacketTypeSetTool = 7,
+				PacketTypeSetColour = 8,
+				PacketTypeExistingPlayer = 9,
+				PacketTypeShortPlayerData = 10,
+				PacketTypeMoveObject = 11,
+				PacketTypeCreatePlayer = 12,
+				PacketTypeBlockAction = 13,
+				PacketTypeBlockLine = 14,
+				PacketTypeStateData = 15,
+				PacketTypeKillAction = 16,
+				PacketTypeChatMessage = 17,
+				PacketTypeMapStart = 18,
+				PacketTypeMapChunk = 19,
+				PacketTypePlayerLeft = 20,
+				PacketTypeTerritoryCapture = 21,
+				PacketTypeProgressBar = 22,
+				PacketTypeIntelCapture = 23,
+				PacketTypeIntelPickup = 24,
+				PacketTypeIntelDrop = 25,
+				PacketTypeRestock = 26,
+				PacketTypeFogColour = 27,
+				PacketTypeWeaponReload = 28,
+				PacketTypeChangeTeam = 29,
+				PacketTypeChangeWeapon = 30,
+				PacketTypePlayerProperties = 64,
+			};
+
+			const char UTFSign = -1;
+
+			std::string DecodeString(std::string s) {
+				if (s.size() > 0 && s[0] == UTFSign)
+					return s.substr(1);
+				return CP437::Decode(s);
+			}
+
+			PlayerInput ParsePlayerInput(uint8_t bits) {
+				PlayerInput inp;
+				inp.moveForward = (bits & (1 << 0)) != 0;
+				inp.moveBackward = (bits & (1 << 1)) != 0;
+				inp.moveLeft = (bits & (1 << 2)) != 0;
+				inp.moveRight = (bits & (1 << 3)) != 0;
+				inp.jump = (bits & (1 << 4)) != 0;
+				inp.crouch = (bits & (1 << 5)) != 0;
+				inp.sneak = (bits & (1 << 6)) != 0;
+				inp.sprint = (bits & (1 << 7)) != 0;
+				return inp;
+			}
+
+			WeaponInput ParseWeaponInput(uint8_t bits) {
+				WeaponInput inp;
+				inp.primary = ((bits & (1 << 0)) != 0);
+				inp.secondary = ((bits & (1 << 1)) != 0);
+				return inp;
+			}
+		} // namespace
+
+		// NetPacketReader for demo playback (simplified version of NetClient's reader)
+		class NetPacketReader {
+			std::vector<char> data;
+			size_t pos;
+
+		public:
+			NetPacketReader(const std::vector<char>& inData) : data(inData), pos(1) {}
+
+			unsigned int GetTypeRaw() { return static_cast<unsigned int>(static_cast<uint8_t>(data[0])); }
+			PacketType GetType() { return static_cast<PacketType>(GetTypeRaw()); }
+
+			uint32_t ReadInt() {
+				if (pos + 4 > data.size())
+					SPRaise("Received packet truncated");
+				uint32_t value = 0;
+				value |= ((uint32_t)(uint8_t)data[pos++]);
+				value |= ((uint32_t)(uint8_t)data[pos++]) << 8;
+				value |= ((uint32_t)(uint8_t)data[pos++]) << 16;
+				value |= ((uint32_t)(uint8_t)data[pos++]) << 24;
+				return value;
+			}
+
+			uint16_t ReadShort() {
+				if (pos + 2 > data.size())
+					SPRaise("Received packet truncated");
+				uint32_t value = 0;
+				value |= ((uint32_t)(uint8_t)data[pos++]);
+				value |= ((uint32_t)(uint8_t)data[pos++]) << 8;
+				return (uint16_t)value;
+			}
+
+			uint8_t ReadByte() {
+				if (pos >= data.size())
+					SPRaise("Received packet truncated");
+				return (uint8_t)data[pos++];
+			}
+
+			float ReadFloat() {
+				union { float f; uint32_t v; };
+				v = ReadInt();
+				return f;
+			}
+
+			IntVector3 ReadIntColor() {
+				IntVector3 col;
+				col.z = ReadByte();
+				col.y = ReadByte();
+				col.x = ReadByte();
+				return col;
+			}
+
+			IntVector3 ReadIntVector3() {
+				IntVector3 v;
+				v.x = ReadInt();
+				v.y = ReadInt();
+				v.z = ReadInt();
+				return v;
+			}
+
+			Vector3 ReadVector3() {
+				Vector3 v;
+				v.x = ReadFloat();
+				v.y = ReadFloat();
+				v.z = ReadFloat();
+				return v;
+			}
+
+			std::size_t GetLength() { return data.size(); }
+			std::size_t GetPosition() { return pos; }
+			std::size_t GetNumRemainingBytes() { return data.size() - pos; }
+			std::vector<char> GetData() { return data; }
+
+			std::string ReadData(size_t siz) {
+				if (pos + siz > data.size())
+					SPRaise("Received packet truncated");
+				std::string s = std::string(data.data() + pos, siz);
+				pos += siz;
+				return s;
+			}
+
+			std::string ReadRemainingData() {
+				return std::string(data.data() + pos, data.size() - pos);
+			}
+
+			std::string ReadString(size_t siz) {
+				return DecodeString(ReadData(siz).c_str());
+			}
+
+			std::string ReadRemainingString() {
+				return DecodeString(ReadRemainingData().c_str());
+			}
+
+			void DumpDebug() {
+				char buf[512];
+				std::string str;
+				int bytes = (int)data.size();
+				sprintf(buf, "Demo Packet 0x%02x [len=%d]", (int)GetType(), bytes);
+				str += buf;
+				if (bytes > 64) bytes = 64;
+				for (int i = 0; i < bytes; i++) {
+					sprintf(buf, " %02x", (unsigned int)(unsigned char)data[i]);
+					str += buf;
+				}
+				SPLog("%s", str.c_str());
+			}
+		};
+
+		DemoNetClient::DemoNetClient(Client* c) : client(c), status(NetClientStatusNotConnected),
+		    protocolVersion(0), lastFrameTime(0.0f), expectedMapSize(0), receivedMapBytes(0),
+		    recordedLocalPlayerId(-1) {
+			SPADES_MARK_FUNCTION();
+
+			demoPlayer.reset(new DemoPlayer());
+
+			const int slots = 256;
+			savedPlayerPos.resize(slots);
+			savedPlayerFront.resize(slots);
+			savedPlayerTeam.resize(slots);
+			std::fill(savedPlayerTeam.begin(), savedPlayerTeam.end(), -1);
+
+			statusString = _Tr("NetClient", "Not connected");
+		}
+
+		DemoNetClient::~DemoNetClient() {
+			SPADES_MARK_FUNCTION();
+
+			if (demoPlayer)
+				demoPlayer->Close();
+		}
+
+		bool DemoNetClient::OpenDemo(const std::string& filename) {
+			SPADES_MARK_FUNCTION();
+
+			if (!demoPlayer->Open(filename)) {
+				statusString = _Tr("NetClient", "Failed to open demo file");
+				return false;
+			}
+
+			protocolVersion = demoPlayer->GetProtocolVersion();
+
+			// Create game properties based on protocol version
+			ProtocolVersion protoVer = (protocolVersion == 4)
+				? ProtocolVersion::v076 : ProtocolVersion::v075;
+			properties.reset(new GameProperties(protoVer));
+
+			status = NetClientStatusConnecting;
+			statusString = _Tr("NetClient", "Loading demo");
+
+			SPLog("Opened demo: %s (protocol %d)", filename.c_str(), protocolVersion);
+			return true;
+		}
+
+		void DemoNetClient::DoEvents(float dt) {
+			SPADES_MARK_FUNCTION();
+
+			if (status == NetClientStatusNotConnected)
+				return;
+
+			lastFrameTime = dt;
+
+			// Process packets from the demo
+			demoPlayer->Update(dt, [this](const std::vector<char>& data) {
+				ProcessPacket(data);
+			});
+
+			// Check if demo finished - auto-pause when complete
+			if (demoPlayer->IsFinished() && status == NetClientStatusConnected && !demoPlayer->IsPaused()) {
+				SPLog("Demo playback finished");
+				statusString = _Tr("NetClient", "Demo finished - press P to replay");
+				demoPlayer->Pause();
+			}
+		}
+
+		void DemoNetClient::ProcessPacket(const std::vector<char>& data) {
+			SPADES_MARK_FUNCTION();
+
+			if (data.empty())
+				return;
+
+			NetPacketReader reader(data);
+
+			try {
+				if (status == NetClientStatusConnecting) {
+					int type = reader.GetType();
+					if (type == PacketTypeMapStart) {
+						auto mapSize = reader.ReadInt();
+						expectedMapSize = mapSize;
+						receivedMapBytes = 0;
+						SPLog("Demo map size: %lu", (unsigned long)mapSize);
+
+						mapLoader.reset(new GameMapLoader());
+						status = NetClientStatusReceivingMap;
+						statusString = _Tr("NetClient", "Loading map from demo");
+					}
+				} else if (status == NetClientStatusReceivingMap) {
+					SPAssert(mapLoader);
+
+					int type = reader.GetType();
+					if (type == PacketTypeMapChunk) {
+						std::vector<char> dt = reader.GetData();
+						size_t chunkSize = dt.size() - 1;
+						receivedMapBytes += chunkSize;
+						mapLoader->AddRawChunk(dt.data() + 1, chunkSize);
+					} else if (type == PacketTypeStateData) {
+						status = NetClientStatusConnected;
+						statusString = _Tr("NetClient", "Playing demo");
+
+						try {
+							MapLoaded();
+						} catch (const std::exception& ex) {
+							SPLog("Map loading error: %s", ex.what());
+							status = NetClientStatusNotConnected;
+							statusString = _Tr("NetClient", "Error loading map");
+							throw;
+						}
+
+						HandleGamePacket(reader);
+					} else {
+						// Save packet for later processing
+						savedPackets.push_back(reader.GetData());
+					}
+				} else if (status == NetClientStatusConnected) {
+					HandleGamePacket(reader);
+				}
+			} catch (const std::exception& ex) {
+				int type = reader.GetType();
+				reader.DumpDebug();
+				SPLog("Exception handling demo packet 0x%02x: %s", type, ex.what());
+			}
+		}
+
+		stmp::optional<World&> DemoNetClient::GetWorld() {
+			return client->GetWorld();
+		}
+
+		stmp::optional<Player&> DemoNetClient::GetPlayerOrNull(int pId) {
+			SPADES_MARK_FUNCTION();
+			if (!GetWorld())
+				return {};
+			if (pId < 0 || pId >= static_cast<int>(GetWorld()->GetNumPlayerSlots()))
+				return {};
+			return GetWorld()->GetPlayer(pId);
+		}
+
+		Player& DemoNetClient::GetPlayer(int pId) {
+			SPADES_MARK_FUNCTION();
+			if (!GetWorld())
+				SPRaise("Invalid player ID %d: no world", pId);
+			if (pId < 0 || pId >= static_cast<int>(GetWorld()->GetNumPlayerSlots()))
+				SPRaise("Invalid player ID %d: out of range", pId);
+			if (!GetWorld()->GetPlayer(pId))
+				SPRaise("Invalid player ID %d: doesn't exist", pId);
+			return GetWorld()->GetPlayer(pId).value();
+		}
+
+		stmp::optional<Player&> DemoNetClient::GetLocalPlayerOrNull() {
+			SPADES_MARK_FUNCTION();
+			if (!GetWorld())
+				return {};
+			return GetWorld()->GetLocalPlayer();
+		}
+
+		Player& DemoNetClient::GetLocalPlayer() {
+			SPADES_MARK_FUNCTION();
+			stmp::optional<Player&> maybePlayer = GetLocalPlayerOrNull();
+			if (!maybePlayer)
+				SPRaise("Failed to get local player: doesn't exist");
+			return maybePlayer.value();
+		}
+
+		void DemoNetClient::HandleGamePacket(NetPacketReader& r) {
+			SPADES_MARK_FUNCTION();
+
+			int packetType = r.GetType();
+
+			switch (packetType) {
+				case PacketTypePositionData: {
+					auto p = GetLocalPlayerOrNull();
+					if (!p) break;
+					if (r.GetLength() != 13) break;
+					p->RepositionPlayer(r.ReadVector3());
+				} break;
+				case PacketTypeOrientationData: {
+					auto p = GetLocalPlayerOrNull();
+					if (!p) break;
+					Vector3 o = r.ReadVector3();
+					if (o.GetSquaredLength() < 0.01F) break;
+					o = o.Normalize();
+					p->SetOrientation(o);
+				} break;
+				case PacketTypeWorldUpdate: {
+					int bytesPerEntry = 24;
+					if (protocolVersion == 4)
+						bytesPerEntry++;
+
+					client->MarkWorldUpdate();
+
+					int entries = static_cast<int>(r.GetLength() / bytesPerEntry);
+					for (int i = 0; i < entries; i++) {
+						int idx = i;
+						if (protocolVersion == 4) {
+							idx = r.ReadByte();
+							if (idx < 0 || idx >= properties->GetMaxNumPlayerSlots())
+								SPRaise("Invalid player ID %d in WorldUpdate", idx);
+						}
+
+						Vector3 pos = r.ReadVector3();
+						Vector3 front = r.ReadVector3();
+
+						if (GetWorld()) {
+							auto p = GetWorld()->GetPlayer(idx);
+							if (p && p != GetWorld()->GetLocalPlayer()
+								&& p->IsAlive() && !p->IsSpectator()) {
+								p->RepositionPlayer(pos);
+								p->SetOrientation(front);
+							}
+						}
+
+						savedPlayerPos.at(idx) = pos;
+						savedPlayerFront.at(idx) = front;
+					}
+				} break;
+				case PacketTypeInputData:
+					if (!GetWorld()) break;
+					{
+						auto p = GetPlayerOrNull(r.ReadByte());
+						PlayerInput inp = ParsePlayerInput(r.ReadByte());
+						if (!p) break;
+						// In demo mode there's no local player (spectating), so check before comparing
+						auto localPlayer = GetLocalPlayerOrNull();
+						if (localPlayer && &*p == &*localPlayer) {
+							if (inp.jump) p->PlayerJump();
+							break;
+						}
+						p->SetInput(inp);
+					}
+					break;
+				case PacketTypeWeaponInput:
+					if (!GetWorld()) break;
+					{
+						auto p = GetPlayerOrNull(r.ReadByte());
+						WeaponInput inp = ParseWeaponInput(r.ReadByte());
+						if (!p) break;
+						// In demo mode there's no local player (spectating), so check before comparing
+						auto localPlayer = GetLocalPlayerOrNull();
+						if (localPlayer && &*p == &*localPlayer) break;
+						p->SetWeaponInput(inp);
+					}
+					break;
+				case PacketTypeSetHP: {
+					auto p = GetLocalPlayerOrNull();
+					if (!p) break;
+					int hp = r.ReadByte();
+					int type = r.ReadByte();
+					Vector3 source = r.ReadVector3();
+					p->SetHP(hp, type ? HurtTypeWeapon : HurtTypeFall, source);
+				} break;
+				case PacketTypeGrenadePacket:
+					if (!GetWorld()) break;
+					{
+						int pId = r.ReadByte();
+						float fuse = r.ReadFloat();
+						Vector3 pos = r.ReadVector3();
+						Vector3 vel = r.ReadVector3();
+						Grenade* g = new Grenade(*GetWorld(), pos, vel, fuse);
+						GetWorld()->AddGrenade(std::unique_ptr<Grenade>{g});
+					}
+					break;
+				case PacketTypeSetTool: {
+					auto p = GetPlayerOrNull(r.ReadByte());
+					int tool = r.ReadByte();
+					if (!p) break;
+					switch (tool) {
+						case 0: p->SetTool(Player::ToolSpade); break;
+						case 1: p->SetTool(Player::ToolBlock); break;
+						case 2: p->SetTool(Player::ToolWeapon); break;
+						case 3: p->SetTool(Player::ToolGrenade); break;
+						default: SPRaise("Invalid tool type: %d", tool);
+					}
+				} break;
+				case PacketTypeSetColour: {
+					stmp::optional<Player&> p = GetPlayerOrNull(r.ReadByte());
+					IntVector3 color = r.ReadIntColor();
+					if (p)
+						p->SetHeldBlockColor(color);
+					else
+						temporaryPlayerBlockColor = color;
+				} break;
+				case PacketTypeExistingPlayer:
+					if (!GetWorld()) break;
+					{
+						int pId = r.ReadByte();
+						if (pId < 0 || pId >= properties->GetMaxNumPlayerSlots()) {
+							SPLog("Ignoring invalid player ID %d in ExistingPlayer", pId);
+							break;
+						}
+
+						int team = r.ReadByte();
+						int weapon = r.ReadByte();
+						int tool = r.ReadByte();
+						int score = r.ReadInt();
+						IntVector3 color = r.ReadIntColor();
+						std::string name = TrimSpaces(r.ReadRemainingString());
+
+						WeaponType wType;
+						switch (weapon) {
+							case 0: wType = RIFLE_WEAPON; break;
+							case 1: wType = SMG_WEAPON; break;
+							case 2: wType = SHOTGUN_WEAPON; break;
+							default: SPRaise("Invalid weapon: %d", weapon);
+						}
+
+						auto p = stmp::make_unique<Player>(*GetWorld(), pId, wType, team);
+						p->SetPosition(savedPlayerPos.at(pId));
+						p->SetHeldBlockColor(color);
+
+						switch (tool) {
+							case 0: p->SetTool(Player::ToolSpade); break;
+							case 1: p->SetTool(Player::ToolBlock); break;
+							case 2: p->SetTool(Player::ToolWeapon); break;
+							case 3: p->SetTool(Player::ToolGrenade); break;
+							default: SPRaise("Invalid tool type: %d", tool);
+						}
+
+						GetWorld()->SetPlayer(pId, std::move(p));
+
+						auto& pers = GetWorld()->GetPlayerPersistent(pId);
+						pers.name = name;
+						pers.score = score;
+
+						savedPlayerTeam.at(pId) = team;
+					}
+					break;
+				case PacketTypeMoveObject: {
+					if (!GetWorld()) SPRaise("No world");
+
+					int type = r.ReadByte();
+					int state = r.ReadByte();
+					Vector3 pos = r.ReadVector3();
+
+					stmp::optional<IGameMode&> mode = GetWorld()->GetMode();
+					if (mode && mode->ModeType() == IGameMode::m_CTF) {
+						auto& ctf = dynamic_cast<CTFGameMode&>(mode.value());
+						CTFGameMode::Team& team1 = ctf.GetTeam(0);
+						CTFGameMode::Team& team2 = ctf.GetTeam(1);
+
+						switch (type) {
+							case BLUE_FLAG: team1.flagPos = pos; break;
+							case BLUE_BASE: team1.basePos = pos; break;
+							case GREEN_FLAG: team2.flagPos = pos; break;
+							case GREEN_BASE: team2.basePos = pos; break;
+						}
+					} else if (mode && mode->ModeType() == IGameMode::m_TC) {
+						auto& tc = dynamic_cast<TCGameMode&>(mode.value());
+						if (type < tc.GetNumTerritories()) {
+							TCGameMode::Territory& t = tc.GetTerritory(type);
+							t.pos = pos;
+							t.ownerTeamId = state;
+						}
+					}
+				} break;
+				case PacketTypeCreatePlayer: {
+					if (!GetWorld()) SPRaise("No world");
+
+					int pId = r.ReadByte();
+					int weapon = r.ReadByte();
+					int team = r.ReadByte();
+					Vector3 pos = r.ReadVector3();
+					std::string name = TrimSpaces(r.ReadRemainingString());
+
+					if (pId < 0 || pId >= properties->GetMaxNumPlayerSlots()) {
+						SPLog("Ignoring invalid player ID %d", pId);
+						break;
+					}
+
+					WeaponType wType;
+					switch (weapon) {
+						case 0: wType = RIFLE_WEAPON; break;
+						case 1: wType = SMG_WEAPON; break;
+						case 2: wType = SHOTGUN_WEAPON; break;
+						default: SPRaise("Invalid weapon: %d", weapon);
+					}
+
+					auto p = stmp::make_unique<Player>(*GetWorld(), pId, wType, team);
+					pos.z -= 2.4F;
+					p->SetPosition(pos);
+
+					GetWorld()->SetPlayer(pId, std::move(p));
+
+					if (!name.empty())
+						GetWorld()->GetPlayerPersistent(pId).name = name;
+
+					Player& pRef = GetWorld()->GetPlayer(pId).value();
+
+					// In demo mode, user is always spectator - track all team changes
+					if (savedPlayerTeam.at(pId) != team) {
+						client->PlayerJoinedTeam(pRef);
+						savedPlayerTeam.at(pId) = team;
+					}
+
+					client->PlayerSpawned(pRef);
+				} break;
+				case PacketTypeBlockAction: {
+					stmp::optional<Player&> p = GetPlayerOrNull(r.ReadByte());
+					int action = r.ReadByte();
+					IntVector3 pos = r.ReadIntVector3();
+
+					std::vector<IntVector3> cells;
+					if (action == BlockActionCreate) {
+						if (!p) {
+							GetWorld()->CreateBlock(pos, temporaryPlayerBlockColor);
+						} else {
+							GetWorld()->CreateBlock(pos, p->GetBlockColor());
+							if (!GetWorld()->GetMap()->IsSolidWrapped(pos.x, pos.y, pos.z)) {
+								p->UseBlocks(1);
+								if (p->IsLocalPlayer())
+									client->RegisterPlacedBlocks(1);
+							}
+							client->PlayerCreatedBlock(*p);
+						}
+					} else if (action == BlockActionTool) {
+						cells.push_back(pos);
+						GetWorld()->DestroyBlock(cells);
+						if (p && p->IsToolSpade())
+							p->GotBlock();
+						client->PlayerDestroyedBlockWithWeaponOrTool(pos);
+					} else if (action == BlockActionDig) {
+						for (int z = -1; z <= 1; z++)
+							cells.push_back(MakeIntVector3(pos.x, pos.y, pos.z + z));
+						GetWorld()->DestroyBlock(cells);
+						client->PlayerDiggedBlock(pos);
+					} else if (action == BlockActionGrenade) {
+						for (int x = -1; x <= 1; x++)
+						for (int y = -1; y <= 1; y++)
+						for (int z = -1; z <= 1; z++)
+							cells.push_back(MakeIntVector3(pos.x + x, pos.y + y, pos.z + z));
+						GetWorld()->DestroyBlock(cells);
+						client->GrenadeDestroyedBlock(pos);
+					}
+				} break;
+				case PacketTypeBlockLine: {
+					stmp::optional<Player&> p = GetPlayerOrNull(r.ReadByte());
+					IntVector3 pos1 = r.ReadIntVector3();
+					IntVector3 pos2 = r.ReadIntVector3();
+
+					auto cells = GetWorld()->CubeLine(pos1, pos2, 50);
+					for (const auto& c : cells) {
+						if (!GetWorld()->GetMap()->IsSolid(c.x, c.y, c.z))
+							GetWorld()->CreateBlock(c, p ? p->GetBlockColor() : temporaryPlayerBlockColor);
+					}
+
+					if (p) {
+						int blocks = static_cast<int>(cells.size());
+						p->UseBlocks(blocks);
+						if (p->IsLocalPlayer())
+							client->RegisterPlacedBlocks(blocks);
+						client->PlayerCreatedBlock(*p);
+					}
+				} break;
+				case PacketTypeStateData:
+					if (!GetWorld()) break;
+					{
+						int pId = r.ReadByte();
+						IntVector3 fogColor = r.ReadIntColor();
+
+						IntVector3 teamColors[2];
+						teamColors[0] = r.ReadIntColor();
+						teamColors[1] = r.ReadIntColor();
+
+						std::string teamNames[2];
+						teamNames[0] = r.ReadString(10);
+						teamNames[1] = r.ReadString(10);
+
+						World::Team& t1 = GetWorld()->GetTeam(0);
+						World::Team& t2 = GetWorld()->GetTeam(1);
+						t1.color = teamColors[0];
+						t2.color = teamColors[1];
+						t1.name = teamNames[0];
+						t2.name = teamNames[1];
+
+						GetWorld()->SetFogColor(fogColor);
+						// In demo mode, don't set local player - we're spectating
+						// Store the recorded player ID for potential follow-cam
+						recordedLocalPlayerId = pId;
+
+						int mode = r.ReadByte();
+						if (mode == CTFGameMode::m_CTF) {
+							auto ctf = stmp::make_unique<CTFGameMode>();
+
+							CTFGameMode::Team& team1 = ctf->GetTeam(0);
+							CTFGameMode::Team& team2 = ctf->GetTeam(1);
+
+							team1.score = r.ReadByte();
+							team2.score = r.ReadByte();
+							ctf->SetCaptureLimit(r.ReadByte());
+
+							int intelFlags = r.ReadByte();
+							team1.hasIntel = (intelFlags & 1) != 0;
+							team2.hasIntel = (intelFlags & 2) != 0;
+
+							if (team2.hasIntel) {
+								team2.carrierId = r.ReadByte();
+								r.ReadData(11);
+							} else {
+								team1.flagPos = r.ReadVector3();
+							}
+
+							if (team1.hasIntel) {
+								team1.carrierId = r.ReadByte();
+								r.ReadData(11);
+							} else {
+								team2.flagPos = r.ReadVector3();
+							}
+
+							team1.basePos = r.ReadVector3();
+							team2.basePos = r.ReadVector3();
+
+							GetWorld()->SetMode(std::move(ctf));
+						} else {
+							auto tc = stmp::make_unique<TCGameMode>(*GetWorld());
+
+							int trNum = r.ReadByte();
+							for (int i = 0; i < trNum; i++) {
+								TCGameMode::Territory t{*tc};
+								t.pos = r.ReadVector3();
+								int state = r.ReadByte();
+								t.ownerTeamId = state;
+								t.progressBasePos = 0.0F;
+								t.progressStartTime = 0.0F;
+								t.progressRate = 0.0F;
+								t.capturingTeamId = -1;
+								tc->AddTerritory(t);
+							}
+
+							GetWorld()->SetMode(std::move(tc));
+						}
+						client->JoinedGame();
+					}
+					break;
+				case PacketTypeKillAction: {
+					int victimId = r.ReadByte();
+					int killerId = r.ReadByte();
+					int kt = r.ReadByte();
+					int respawnTime = r.ReadByte();
+
+					KillType type;
+					switch (kt) {
+						case 0: type = KillTypeWeapon; break;
+						case 1: type = KillTypeHeadshot; break;
+						case 2: type = KillTypeMelee; break;
+						case 3: type = KillTypeGrenade; break;
+						case 4: type = KillTypeFall; break;
+						case 5: type = KillTypeTeamChange; break;
+						case 6: type = KillTypeClassChange; break;
+						default: SPInvalidEnum("kt", kt);
+					}
+					switch (type) {
+						case KillTypeFall:
+						case KillTypeTeamChange:
+						case KillTypeClassChange: killerId = victimId; break;
+						default: break;
+					}
+
+					auto victim = GetPlayerOrNull(victimId);
+					auto killer = GetPlayerOrNull(killerId);
+					if (!victim || !killer) {
+						SPLog("Demo: KillAction skipped - player not found (victim=%d, killer=%d)", victimId, killerId);
+						break;
+					}
+					victim->KilledBy(type, *killer, respawnTime);
+					if (killerId != victimId)
+						GetWorld()->GetPlayerPersistent(killerId).score++;
+				} break;
+				case PacketTypeChatMessage: {
+					int playerId = r.ReadByte();
+					int type = r.ReadByte();
+					std::string msg = TrimSpaces(r.ReadRemainingString());
+
+					if (type == 2) { // System
+						client->ServerSentMessage(false, msg);
+						properties->HandleServerMessage(msg);
+					} else if (type == 0 || type == 1) { // All or Team
+						stmp::optional<Player&> p = GetPlayerOrNull(playerId);
+						if (p) {
+							client->PlayerSentChatMessage(*p, (type == 0), msg);
+						} else {
+							client->ServerSentMessage((type == 1), msg);
+						}
+					}
+				} break;
+				case PacketTypePlayerLeft: {
+					int pId = r.ReadByte();
+					auto p = GetPlayerOrNull(pId);
+					if (p)
+						client->PlayerLeaving(*p);
+					GetWorld()->GetPlayerPersistent(pId).score = 0;
+					if (pId >= 0 && pId < (int)savedPlayerTeam.size())
+						savedPlayerTeam[pId] = -1;
+					GetWorld()->SetPlayer(pId, NULL);
+				} break;
+				case PacketTypeTerritoryCapture: {
+					int territoryId = r.ReadByte();
+					bool winning = r.ReadByte() != 0;
+					int state = r.ReadByte();
+
+					stmp::optional<IGameMode&> mode = GetWorld()->GetMode();
+					if (!mode || mode->ModeType() != IGameMode::m_TC) break;
+
+					auto& tc = dynamic_cast<TCGameMode&>(*mode);
+					if (territoryId >= tc.GetNumTerritories()) break;
+
+					client->TeamCapturedTerritory(state, territoryId);
+
+					TCGameMode::Territory& t = tc.GetTerritory(territoryId);
+					t.ownerTeamId = state;
+					t.progressBasePos = 0.0F;
+					t.progressRate = 0.0F;
+					t.progressStartTime = 0.0F;
+					t.capturingTeamId = -1;
+
+					if (winning)
+						client->TeamWon(state);
+				} break;
+				case PacketTypeProgressBar: {
+					int territoryId = r.ReadByte();
+					int capturingTeam = r.ReadByte();
+					int rate = (int8_t)r.ReadByte();
+					float progress = r.ReadFloat();
+
+					stmp::optional<IGameMode&> mode = GetWorld()->GetMode();
+					if (!mode || mode->ModeType() != IGameMode::m_TC) break;
+
+					auto& tc = dynamic_cast<TCGameMode&>(*mode);
+					if (territoryId >= tc.GetNumTerritories()) break;
+
+					TCGameMode::Territory& t = tc.GetTerritory(territoryId);
+					t.progressBasePos = progress;
+					t.progressRate = (float)rate * TC_CAPTURE_RATE;
+					t.progressStartTime = GetWorld()->GetTime();
+					t.capturingTeamId = capturingTeam;
+				} break;
+				case PacketTypeIntelCapture: {
+					if (!GetWorld()) break;
+
+					stmp::optional<IGameMode&> mode = GetWorld()->GetMode();
+					if (!mode || mode->ModeType() != IGameMode::m_CTF) break;
+
+					int pId = r.ReadByte();
+					auto p = GetPlayerOrNull(pId);
+					if (!p) break;
+					int teamId = p->GetTeamId();
+
+					auto& ctf = dynamic_cast<CTFGameMode&>(mode.value());
+					CTFGameMode::Team& team = ctf.GetTeam(teamId);
+					team.score++;
+					team.hasIntel = false;
+
+					client->PlayerCapturedIntel(*p);
+					GetWorld()->GetPlayerPersistent(pId).score += 10;
+
+					bool winning = r.ReadByte() != 0;
+					if (winning) {
+						client->TeamWon(teamId);
+						ctf.ResetIntelHoldingStatus();
+					}
+				} break;
+				case PacketTypeIntelPickup: {
+					stmp::optional<IGameMode&> mode = GetWorld()->GetMode();
+					if (!mode || mode->ModeType() != IGameMode::m_CTF) break;
+
+					int pId = r.ReadByte();
+					auto p = GetPlayerOrNull(pId);
+					if (!p) break;
+
+					auto& ctf = dynamic_cast<CTFGameMode&>(mode.value());
+					CTFGameMode::Team& team = ctf.GetTeam(p->GetTeamId());
+					team.hasIntel = true;
+					team.carrierId = pId;
+					client->PlayerPickedIntel(*p);
+				} break;
+				case PacketTypeIntelDrop: {
+					stmp::optional<IGameMode&> mode = GetWorld()->GetMode();
+					if (!mode || mode->ModeType() != IGameMode::m_CTF) break;
+
+					int pId = r.ReadByte();
+					auto p = GetPlayerOrNull(pId);
+					if (!p) break;
+					int teamId = p->GetTeamId();
+
+					auto& ctf = dynamic_cast<CTFGameMode&>(mode.value());
+					ctf.GetTeam(teamId).hasIntel = false;
+					ctf.GetTeam(1 - teamId).flagPos = r.ReadVector3();
+					client->PlayerDropIntel(*p);
+				} break;
+				case PacketTypeRestock: {
+					r.ReadByte();
+					auto p = GetLocalPlayerOrNull();
+					if (p) p->Restock();
+				} break;
+				case PacketTypeFogColour: {
+					if (GetWorld()) {
+						r.ReadByte();
+						GetWorld()->SetFogColor(r.ReadIntColor());
+					}
+				} break;
+				case PacketTypeWeaponReload: {
+					auto p = GetPlayerOrNull(r.ReadByte());
+					if (!p) break;
+					auto localPlayer = GetLocalPlayerOrNull();
+					if (&*p != localPlayer) {
+						p->Reload();
+					} else {
+						int clip = r.ReadByte();
+						int reserve = r.ReadByte();
+						p->ReloadDone(clip, reserve);
+					}
+				} break;
+				case PacketTypeChangeTeam:
+				case PacketTypeChangeWeapon:
+					// These packets are ignored in demo playback
+					break;
+				case PacketTypePlayerProperties: {
+					int subId = r.ReadByte();
+					int pId = r.ReadByte();
+					int hp = r.ReadByte();
+					int blocks = r.ReadByte();
+					int grenades = r.ReadByte();
+					int clip = r.ReadByte();
+					int reserve = r.ReadByte();
+					int score = r.ReadByte();
+
+					auto p = GetPlayerOrNull(pId);
+					if (!p) break;
+					Weapon& w = p->GetWeapon();
+
+					// In demo mode, use recorded local player ID for restock
+					if (pId == recordedLocalPlayerId)
+						p->Restock(hp, grenades, blocks);
+					w.Restock(clip, reserve);
+					GetWorld()->GetPlayerPersistent(pId).score = score;
+				} break;
+				default:
+					SPLog("Demo: dropped unknown packet %d", (int)r.GetType());
+					break;
+			}
+		}
+
+		void DemoNetClient::MapLoaded() {
+			SPADES_MARK_FUNCTION();
+
+			SPAssert(mapLoader);
+
+			std::unique_ptr<GameMapLoader> loader = std::move(mapLoader);
+
+			SPLog("Waiting for demo map decoding... (received %zu bytes)", receivedMapBytes);
+			loader->MarkEOF();
+			loader->WaitComplete();
+			GameMap* map = loader->TakeGameMap().Unmanage();
+			SPLog("Demo map decoded successfully.");
+
+			World* w = new World(properties);
+			w->SetMap(map);
+			map->Release();
+			SPLog("Demo world initialized.");
+
+			client->SetWorld(w);
+
+			SPAssert(GetWorld());
+
+			SPLog("Processing %d saved demo packets...", (int)savedPackets.size());
+
+			std::fill(savedPlayerTeam.begin(), savedPlayerTeam.end(), -1);
+
+			try {
+				for (const auto& packets : savedPackets) {
+					NetPacketReader r(packets);
+					HandleGamePacket(r);
+				}
+				savedPackets.clear();
+				SPLog("Demo packets processed.");
+			} catch (...) {
+				savedPackets.clear();
+				throw;
+			}
+		}
+
+		float DemoNetClient::GetMapReceivingProgress() {
+			if (status != NetClientStatusReceivingMap || !mapLoader)
+				return 0.0f;
+			return mapLoader->GetProgress();
+		}
+
+		std::string DemoNetClient::GetStatusString() {
+			if (status == NetClientStatusReceivingMap && mapLoader) {
+				float progress = mapLoader->GetProgress();
+				return Format("{0} ({1}%)", statusString, (int)(progress * 100.0f));
+			}
+			return statusString;
+		}
+
+		void DemoNetClient::Seek(float time) {
+			if (!demoPlayer) return;
+
+			// Adjust playback time - note that seeking backward may result in
+			// inconsistent world state since packets won't be re-applied
+			demoPlayer->Seek(time);
+			statusString = _Tr("NetClient", "Playing demo");
+		}
+
+		void DemoNetClient::SeekToBeginning() {
+			if (!demoPlayer) return;
+
+			// Seek to beginning of timeline without reloading the world
+			// Note: World state may be inconsistent, but allows video-player-like scrubbing
+			demoPlayer->Seek(0.0f);
+			demoPlayer->Resume();
+			statusString = _Tr("NetClient", "Playing demo");
+		}
+
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -24,6 +24,7 @@
 #include "CTFGameMode.h"
 #include "Client.h"
 #include "DemoNetClient.h"
+#include "NetProtocol.h"
 #include "GameMap.h"
 #include "GameMapLoader.h"
 #include "GameProperties.h"
@@ -32,7 +33,6 @@
 #include "TCGameMode.h"
 #include "Weapon.h"
 #include "World.h"
-#include <Core/CP437.h>
 #include <Core/Debug.h>
 #include <Core/Exception.h>
 #include <Core/Settings.h>
@@ -82,178 +82,6 @@ namespace spades {
 			};
 		} // anonymous namespace (SilentWorldListener)
 
-		namespace {
-			enum { BLUE_FLAG = 0, GREEN_FLAG = 1, BLUE_BASE = 2, GREEN_BASE = 3 };
-			enum PacketType {
-				PacketTypePositionData = 0,
-				PacketTypeOrientationData = 1,
-				PacketTypeWorldUpdate = 2,
-				PacketTypeInputData = 3,
-				PacketTypeWeaponInput = 4,
-				PacketTypeSetHP = 5,
-				PacketTypeGrenadePacket = 6,
-				PacketTypeSetTool = 7,
-				PacketTypeSetColour = 8,
-				PacketTypeExistingPlayer = 9,
-				PacketTypeShortPlayerData = 10,
-				PacketTypeMoveObject = 11,
-				PacketTypeCreatePlayer = 12,
-				PacketTypeBlockAction = 13,
-				PacketTypeBlockLine = 14,
-				PacketTypeStateData = 15,
-				PacketTypeKillAction = 16,
-				PacketTypeChatMessage = 17,
-				PacketTypeMapStart = 18,
-				PacketTypeMapChunk = 19,
-				PacketTypePlayerLeft = 20,
-				PacketTypeTerritoryCapture = 21,
-				PacketTypeProgressBar = 22,
-				PacketTypeIntelCapture = 23,
-				PacketTypeIntelPickup = 24,
-				PacketTypeIntelDrop = 25,
-				PacketTypeRestock = 26,
-				PacketTypeFogColour = 27,
-				PacketTypeWeaponReload = 28,
-				PacketTypeChangeTeam = 29,
-				PacketTypeChangeWeapon = 30,
-				PacketTypePlayerProperties = 64,
-			};
-
-			const char UTFSign = -1;
-
-			std::string DecodeString(std::string s) {
-				if (s.size() > 0 && s[0] == UTFSign)
-					return s.substr(1);
-				return CP437::Decode(s);
-			}
-
-			PlayerInput ParsePlayerInput(uint8_t bits) {
-				PlayerInput inp;
-				inp.moveForward = (bits & (1 << 0)) != 0;
-				inp.moveBackward = (bits & (1 << 1)) != 0;
-				inp.moveLeft = (bits & (1 << 2)) != 0;
-				inp.moveRight = (bits & (1 << 3)) != 0;
-				inp.jump = (bits & (1 << 4)) != 0;
-				inp.crouch = (bits & (1 << 5)) != 0;
-				inp.sneak = (bits & (1 << 6)) != 0;
-				inp.sprint = (bits & (1 << 7)) != 0;
-				return inp;
-			}
-
-			WeaponInput ParseWeaponInput(uint8_t bits) {
-				WeaponInput inp;
-				inp.primary = ((bits & (1 << 0)) != 0);
-				inp.secondary = ((bits & (1 << 1)) != 0);
-				return inp;
-			}
-		} // namespace
-
-		// NetPacketReader for demo playback (simplified version of NetClient's reader)
-		class NetPacketReader {
-			std::vector<char> data;
-			size_t pos;
-
-		public:
-			NetPacketReader(const std::vector<char>& inData) : data(inData), pos(1) {}
-
-			unsigned int GetTypeRaw() { return static_cast<unsigned int>(static_cast<uint8_t>(data[0])); }
-			PacketType GetType() { return static_cast<PacketType>(GetTypeRaw()); }
-
-			uint32_t ReadInt() {
-				if (pos + 4 > data.size())
-					SPRaise("Received packet truncated");
-				uint32_t value = 0;
-				value |= ((uint32_t)(uint8_t)data[pos++]);
-				value |= ((uint32_t)(uint8_t)data[pos++]) << 8;
-				value |= ((uint32_t)(uint8_t)data[pos++]) << 16;
-				value |= ((uint32_t)(uint8_t)data[pos++]) << 24;
-				return value;
-			}
-
-			uint16_t ReadShort() {
-				if (pos + 2 > data.size())
-					SPRaise("Received packet truncated");
-				uint32_t value = 0;
-				value |= ((uint32_t)(uint8_t)data[pos++]);
-				value |= ((uint32_t)(uint8_t)data[pos++]) << 8;
-				return (uint16_t)value;
-			}
-
-			uint8_t ReadByte() {
-				if (pos >= data.size())
-					SPRaise("Received packet truncated");
-				return (uint8_t)data[pos++];
-			}
-
-			float ReadFloat() {
-				union { float f; uint32_t v; };
-				v = ReadInt();
-				return f;
-			}
-
-			IntVector3 ReadIntColor() {
-				IntVector3 col;
-				col.z = ReadByte();
-				col.y = ReadByte();
-				col.x = ReadByte();
-				return col;
-			}
-
-			IntVector3 ReadIntVector3() {
-				IntVector3 v;
-				v.x = ReadInt();
-				v.y = ReadInt();
-				v.z = ReadInt();
-				return v;
-			}
-
-			Vector3 ReadVector3() {
-				Vector3 v;
-				v.x = ReadFloat();
-				v.y = ReadFloat();
-				v.z = ReadFloat();
-				return v;
-			}
-
-			std::size_t GetLength() { return data.size(); }
-			std::size_t GetPosition() { return pos; }
-			std::size_t GetNumRemainingBytes() { return data.size() - pos; }
-			std::vector<char> GetData() { return data; }
-
-			std::string ReadData(size_t siz) {
-				if (pos + siz > data.size())
-					SPRaise("Received packet truncated");
-				std::string s = std::string(data.data() + pos, siz);
-				pos += siz;
-				return s;
-			}
-
-			std::string ReadRemainingData() {
-				return std::string(data.data() + pos, data.size() - pos);
-			}
-
-			std::string ReadString(size_t siz) {
-				return DecodeString(ReadData(siz).c_str());
-			}
-
-			std::string ReadRemainingString() {
-				return DecodeString(ReadRemainingData().c_str());
-			}
-
-			void DumpDebug() {
-				char buf[512];
-				std::string str;
-				int bytes = (int)data.size();
-				sprintf(buf, "Demo Packet 0x%02x [len=%d]", (int)GetType(), bytes);
-				str += buf;
-				if (bytes > 64) bytes = 64;
-				for (int i = 0; i < bytes; i++) {
-					sprintf(buf, " %02x", (unsigned int)(unsigned char)data[i]);
-					str += buf;
-				}
-				SPLog("%s", str.c_str());
-			}
-		};
 
 		DemoNetClient::DemoNetClient(Client* c) : client(c), status(NetClientStatusNotConnected),
 		    protocolVersion(0), expectedMapSize(0), receivedMapBytes(0),

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -115,10 +115,13 @@ namespace spades {
 				return false;
 			}
 
-			// Create game properties based on protocol version
+			// Create game properties based on protocol version.
+			// The demo viewer is always considered staff so admin-only
+			// tools (free third-person, ESP boxes) are available for review.
 			ProtocolVersion protoVer = (demoPlayer->GetProtocolVersion() == 4)
 				? ProtocolVersion::v076 : ProtocolVersion::v075;
 			properties.reset(new GameProperties(protoVer));
+			properties->isStaff = true;
 
 			status = NetClientStatusConnecting;
 			statusString = _Tr("NetClient", "Loading demo");

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -962,10 +962,17 @@ namespace spades {
 		void DemoNetClient::Seek(float time) {
 			if (!demoPlayer) return;
 
+			// FastReplay must always cover the bootstrap region so that the
+			// rebuilt world has its game mode, teams and players (and so that
+			// recordedLocalPlayerId is restored) — otherwise seeking back to
+			// t=0 would leave the world empty and crash any subsequent draw
+			// that dereferences the camera-target player.
+			float replayTime = std::max(time, demoPlayer->GetBootstrapEndTime());
+
 			if (initialMap) {
 				auto view = client->SaveViewState();
 				ResetWorldForReplay();
-				FastReplay(time);
+				FastReplay(replayTime);
 				client->RestoreViewState(view);
 			}
 
@@ -984,7 +991,7 @@ namespace spades {
 			if (initialMap && demoPlayer->GetTime() > 0.0f) {
 				auto view = client->SaveViewState();
 				ResetWorldForReplay();
-				FastReplay(0.0f);
+				FastReplay(demoPlayer->GetBootstrapEndTime());
 				client->RestoreViewState(view);
 			}
 

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -931,9 +931,22 @@ namespace spades {
 			}
 
 			try {
-				demoPlayer->ReplayUpTo(targetTime, [this](const std::vector<char>& data) {
-					ProcessPacket(data);
-				});
+				demoPlayer->ReplayUpTo(targetTime,
+				    [this](const std::vector<char>& data, float dt) {
+					    ProcessPacket(data);
+					    // Age world physics in fixed steps so grenade fuses, falling
+					    // blocks, etc. resolve at their correct demo timestamps under
+					    // the silent listener instead of firing after replay finishes.
+					    if (auto w = GetWorld()) {
+						    const float step = 1.0f / 60.0f;
+						    while (dt >= step) {
+							    w->Advance(step);
+							    dt -= step;
+						    }
+						    if (dt > 0.0f)
+							    w->Advance(dt);
+					    }
+				    });
 			} catch (...) {
 				if (GetWorld())
 					GetWorld()->SetListener(savedListener);

--- a/Sources/Client/DemoNetClient.cpp
+++ b/Sources/Client/DemoNetClient.cpp
@@ -1,21 +1,22 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2026 Francois ND
+ based on code of OpenSpades (c) yvt 2013.
  based on code of pysnip (c) Mathias Kaerlev 2011-2012.
 
- This file is part of OpenSpades.
+ This file is part of ZeroSpades, a fork of OpenSpades.
 
- OpenSpades is free software: you can redistribute it and/or modify
+ ZeroSpades is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- OpenSpades is distributed in the hope that it will be useful,
+ ZeroSpades is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
 

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -52,7 +52,7 @@ namespace spades {
 			int protocolVersion;
 
 			// Packet handling state (mirrors NetClient)
-			std::vector<std::vector<char>> savedPackets;
+			std::vector<std::vector<char>> preMapPackets;
 			std::vector<Vector3> savedPlayerPos;
 			std::vector<Vector3> savedPlayerFront;
 			std::vector<int> savedPlayerTeam;

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -50,7 +50,6 @@ namespace spades {
 			std::shared_ptr<GameProperties> properties;
 			std::string statusString;
 			int protocolVersion;
-			float lastFrameTime;
 
 			// Packet handling state (mirrors NetClient)
 			std::vector<std::vector<char>> savedPackets;

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -109,6 +109,12 @@ namespace spades {
 			void TogglePause() { if (demoPlayer) demoPlayer->TogglePause(); }
 			void SetSpeed(float speed) { if (demoPlayer) demoPlayer->SetSpeed(speed); }
 			void Seek(float time);
+			/**
+			 * Updates the displayed playback position without replaying world state.
+			 * Use during interactive scrubbing to keep the HUD responsive; call Seek()
+			 * once scrubbing ends to commit the world to the new position.
+			 */
+			void SeekPreview(float time);
 			void SeekToBeginning();
 			float GetTime() const { return demoPlayer ? demoPlayer->GetTime() : 0.0f; }
 			float GetDuration() const { return demoPlayer ? demoPlayer->GetDuration() : 0.0f; }

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -102,7 +102,7 @@ namespace spades {
 			NetClientStatus GetStatus() override { return status; }
 			std::string GetStatusString() override;
 			float GetMapReceivingProgress() override;
-			std::shared_ptr<GameProperties>& GetGameProperties() override { return properties; }
+			const std::shared_ptr<GameProperties>& GetGameProperties() override { return properties; }
 
 			// Playback controls (DemoNetClient-specific, not in INetClient)
 			void Pause() { if (demoPlayer) demoPlayer->Pause(); }

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -141,17 +141,6 @@ namespace spades {
 			void SendTeamChange(int) override {}
 			void SendWeaponChange(WeaponType) override {}
 
-			// Demo recording is not applicable during playback
-			bool StartDemoRecording(const std::string& = "",
-			                        const std::string& = "") override { return false; }
-			void StopDemoRecording() override {}
-			bool IsDemoRecording() const override { return false; }
-			float GetDemoRecordingTime() const override { return 0.0f; }
-			uint64_t GetDemoPacketCount() const override { return 0; }
-			const std::string& GetDemoFilename() const override {
-				static std::string empty;
-				return empty;
-			}
 		};
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -49,7 +49,6 @@ namespace spades {
 			std::unique_ptr<GameMapLoader> mapLoader;
 			std::shared_ptr<GameProperties> properties;
 			std::string statusString;
-			int protocolVersion;
 
 			// Packet handling state (mirrors NetClient)
 			std::vector<std::vector<char>> preMapPackets;

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -27,7 +27,7 @@
 #include "DemoPlayer.h"
 #include "GameConstants.h"
 #include "GameMap.h"
-#include "NetClient.h"
+#include "INetClient.h"
 #include "Player.h"
 #include <Core/Math.h>
 
@@ -42,7 +42,7 @@ namespace spades {
 		 * a demo file instead of from the network. This allows the Client class to
 		 * play back recorded demos with minimal changes.
 		 */
-		class DemoNetClient {
+		class DemoNetClient : public INetClient {
 			Client* client;
 			NetClientStatus status;
 			std::unique_ptr<DemoPlayer> demoPlayer;
@@ -88,7 +88,7 @@ namespace spades {
 
 		public:
 			DemoNetClient(Client* client);
-			~DemoNetClient();
+			~DemoNetClient() override;
 
 			/**
 			 * Opens a demo file for playback.
@@ -97,18 +97,14 @@ namespace spades {
 			 */
 			bool OpenDemo(const std::string& filename);
 
-			/**
-			 * Process demo packets for the current frame.
-			 * @param dt Delta time since last frame
-			 */
-			void DoEvents(float dt);
+			// INetClient interface
+			void DoEvents(float dt) override;
+			NetClientStatus GetStatus() override { return status; }
+			std::string GetStatusString() override;
+			float GetMapReceivingProgress() override;
+			std::shared_ptr<GameProperties>& GetGameProperties() override { return properties; }
 
-			NetClientStatus GetStatus() { return status; }
-			std::string GetStatusString();
-			float GetMapReceivingProgress();
-			std::shared_ptr<GameProperties>& GetGameProperties() { return properties; }
-
-			// Playback controls
+			// Playback controls (DemoNetClient-specific, not in INetClient)
 			void Pause() { if (demoPlayer) demoPlayer->Pause(); }
 			void Resume() { if (demoPlayer) demoPlayer->Resume(); }
 			void TogglePause() { if (demoPlayer) demoPlayer->TogglePause(); }
@@ -122,38 +118,38 @@ namespace spades {
 			float GetSpeed() const { return demoPlayer ? demoPlayer->GetSpeed() : 1.0f; }
 			int GetRecordedLocalPlayerId() const { return recordedLocalPlayerId; }
 
-			// Stub methods (no-op in demo mode - we don't send anything to a server)
-			void Disconnect() { status = NetClientStatusNotConnected; }
-			int GetPing() { return 0; }
-			float GetPacketLoss() { return 0.0f; }
-			float GetPacketThrottle() { return 1.0f; }
-			double GetDownlinkBps() { return 0.0; }
-			double GetUplinkBps() { return 0.0; }
+			// Stub network methods (no-ops — demo playback sends nothing to a server)
+			void Disconnect() override { status = NetClientStatusNotConnected; }
+			int GetPing() override { return 0; }
+			float GetPacketLoss() override { return 0.0f; }
+			float GetPacketThrottle() override { return 1.0f; }
+			double GetDownlinkBps() override { return 0.0; }
+			double GetUplinkBps() override { return 0.0; }
 
-			// Send methods are all no-ops in demo mode
-			void SendJoin(int, WeaponType, std::string, int) {}
-			void SendPosition(Vector3) {}
-			void SendOrientation(Vector3) {}
-			void SendPlayerInput(PlayerInput) {}
-			void SendWeaponInput(WeaponInput) {}
-			void SendHit(int, HitType) {}
-			void SendGrenade(const Grenade&) {}
-			void SendTool() {}
-			void SendHeldBlockColor() {}
-			void SendBlockAction(IntVector3, BlockActionType) {}
-			void SendBlockLine(IntVector3, IntVector3) {}
-			void SendChat(std::string, bool) {}
-			void SendReload() {}
-			void SendTeamChange(int) {}
-			void SendWeaponChange(WeaponType) {}
+			void SendJoin(int, WeaponType, std::string, int) override {}
+			void SendPosition(Vector3) override {}
+			void SendOrientation(Vector3) override {}
+			void SendPlayerInput(PlayerInput) override {}
+			void SendWeaponInput(WeaponInput) override {}
+			void SendHit(int, HitType) override {}
+			void SendGrenade(const Grenade&) override {}
+			void SendTool() override {}
+			void SendHeldBlockColor() override {}
+			void SendBlockAction(IntVector3, BlockActionType) override {}
+			void SendBlockLine(IntVector3, IntVector3) override {}
+			void SendChat(std::string, bool) override {}
+			void SendReload() override {}
+			void SendTeamChange(int) override {}
+			void SendWeaponChange(WeaponType) override {}
 
-			// Demo recording is not applicable in playback mode
-			bool StartDemoRecording(const std::string& = "") { return false; }
-			void StopDemoRecording() {}
-			bool IsDemoRecording() const { return false; }
-			float GetDemoRecordingTime() const { return 0.0f; }
-			uint64_t GetDemoPacketCount() const { return 0; }
-			const std::string& GetDemoFilename() const {
+			// Demo recording is not applicable during playback
+			bool StartDemoRecording(const std::string& = "",
+			                        const std::string& = "") override { return false; }
+			void StopDemoRecording() override {}
+			bool IsDemoRecording() const override { return false; }
+			float GetDemoRecordingTime() const override { return 0.0f; }
+			uint64_t GetDemoPacketCount() const override { return 0; }
+			const std::string& GetDemoFilename() const override {
 				static std::string empty;
 				return empty;
 			}

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -26,6 +26,7 @@
 
 #include "DemoPlayer.h"
 #include "GameConstants.h"
+#include "GameMap.h"
 #include "NetClient.h"
 #include "Player.h"
 #include <Core/Math.h>
@@ -65,6 +66,12 @@ namespace spades {
 			// The player ID that was recorded as local player (for follow-cam)
 			int recordedLocalPlayerId;
 
+			// Snapshot of the map at t=0 (after MapLoaded), used to restore state on backward seek
+			Handle<GameMap> initialMap;
+
+			// True while fast-replaying packets after a backward seek; suppresses client callbacks
+			bool seekingMode;
+
 			stmp::optional<World&> GetWorld();
 			Player& GetPlayer(int);
 			stmp::optional<Player&> GetPlayerOrNull(int);
@@ -74,6 +81,11 @@ namespace spades {
 			void ProcessPacket(const std::vector<char>& data);
 			void HandleGamePacket(class NetPacketReader& reader);
 			void MapLoaded();
+
+			// Reset the world to initial map state and reset tracking variables
+			void ResetWorldForReplay();
+			// Replay all demo packets from index 0 up to targetTime with seekingMode=true
+			void FastReplay(float targetTime);
 
 		public:
 			DemoNetClient(Client* client);

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -1,20 +1,21 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2026 Francois ND
+ based on code of OpenSpades (c) yvt 2013.
 
- This file is part of OpenSpades.
+ This file is part of ZeroSpades, a fork of OpenSpades.
 
- OpenSpades is free software: you can redistribute it and/or modify
+ ZeroSpades is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- OpenSpades is distributed in the hope that it will be useful,
+ ZeroSpades is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
 

--- a/Sources/Client/DemoNetClient.h
+++ b/Sources/Client/DemoNetClient.h
@@ -1,0 +1,151 @@
+/*
+ Copyright (c) 2013 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "DemoPlayer.h"
+#include "GameConstants.h"
+#include "NetClient.h"
+#include "Player.h"
+#include <Core/Math.h>
+
+namespace spades {
+	namespace client {
+		class Client;
+		class GameMapLoader;
+		struct GameProperties;
+
+		/**
+		 * DemoNetClient provides a NetClient-like interface that reads packets from
+		 * a demo file instead of from the network. This allows the Client class to
+		 * play back recorded demos with minimal changes.
+		 */
+		class DemoNetClient {
+			Client* client;
+			NetClientStatus status;
+			std::unique_ptr<DemoPlayer> demoPlayer;
+			std::unique_ptr<GameMapLoader> mapLoader;
+			std::shared_ptr<GameProperties> properties;
+			std::string statusString;
+			int protocolVersion;
+			float lastFrameTime;
+
+			// Packet handling state (mirrors NetClient)
+			std::vector<std::vector<char>> savedPackets;
+			std::vector<Vector3> savedPlayerPos;
+			std::vector<Vector3> savedPlayerFront;
+			std::vector<int> savedPlayerTeam;
+			IntVector3 temporaryPlayerBlockColor;
+
+			// Debug tracking for map loading
+			size_t expectedMapSize;
+			size_t receivedMapBytes;
+
+			// The player ID that was recorded as local player (for follow-cam)
+			int recordedLocalPlayerId;
+
+			stmp::optional<World&> GetWorld();
+			Player& GetPlayer(int);
+			stmp::optional<Player&> GetPlayerOrNull(int);
+			Player& GetLocalPlayer();
+			stmp::optional<Player&> GetLocalPlayerOrNull();
+
+			void ProcessPacket(const std::vector<char>& data);
+			void HandleGamePacket(class NetPacketReader& reader);
+			void MapLoaded();
+
+		public:
+			DemoNetClient(Client* client);
+			~DemoNetClient();
+
+			/**
+			 * Opens a demo file for playback.
+			 * @param filename Path to the demo file
+			 * @return true if successful
+			 */
+			bool OpenDemo(const std::string& filename);
+
+			/**
+			 * Process demo packets for the current frame.
+			 * @param dt Delta time since last frame
+			 */
+			void DoEvents(float dt);
+
+			NetClientStatus GetStatus() { return status; }
+			std::string GetStatusString();
+			float GetMapReceivingProgress();
+			std::shared_ptr<GameProperties>& GetGameProperties() { return properties; }
+
+			// Playback controls
+			void Pause() { if (demoPlayer) demoPlayer->Pause(); }
+			void Resume() { if (demoPlayer) demoPlayer->Resume(); }
+			void TogglePause() { if (demoPlayer) demoPlayer->TogglePause(); }
+			void SetSpeed(float speed) { if (demoPlayer) demoPlayer->SetSpeed(speed); }
+			void Seek(float time);
+			void SeekToBeginning();
+			float GetTime() const { return demoPlayer ? demoPlayer->GetTime() : 0.0f; }
+			float GetDuration() const { return demoPlayer ? demoPlayer->GetDuration() : 0.0f; }
+			bool IsFinished() const { return demoPlayer ? demoPlayer->IsFinished() : true; }
+			bool IsPaused() const { return demoPlayer ? demoPlayer->IsPaused() : false; }
+			float GetSpeed() const { return demoPlayer ? demoPlayer->GetSpeed() : 1.0f; }
+			int GetRecordedLocalPlayerId() const { return recordedLocalPlayerId; }
+
+			// Stub methods (no-op in demo mode - we don't send anything to a server)
+			void Disconnect() { status = NetClientStatusNotConnected; }
+			int GetPing() { return 0; }
+			float GetPacketLoss() { return 0.0f; }
+			float GetPacketThrottle() { return 1.0f; }
+			double GetDownlinkBps() { return 0.0; }
+			double GetUplinkBps() { return 0.0; }
+
+			// Send methods are all no-ops in demo mode
+			void SendJoin(int, WeaponType, std::string, int) {}
+			void SendPosition(Vector3) {}
+			void SendOrientation(Vector3) {}
+			void SendPlayerInput(PlayerInput) {}
+			void SendWeaponInput(WeaponInput) {}
+			void SendHit(int, HitType) {}
+			void SendGrenade(const Grenade&) {}
+			void SendTool() {}
+			void SendHeldBlockColor() {}
+			void SendBlockAction(IntVector3, BlockActionType) {}
+			void SendBlockLine(IntVector3, IntVector3) {}
+			void SendChat(std::string, bool) {}
+			void SendReload() {}
+			void SendTeamChange(int) {}
+			void SendWeaponChange(WeaponType) {}
+
+			// Demo recording is not applicable in playback mode
+			bool StartDemoRecording(const std::string& = "") { return false; }
+			void StopDemoRecording() {}
+			bool IsDemoRecording() const { return false; }
+			float GetDemoRecordingTime() const { return 0.0f; }
+			uint64_t GetDemoPacketCount() const { return 0; }
+			const std::string& GetDemoFilename() const {
+				static std::string empty;
+				return empty;
+			}
+		};
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/DemoPlayer.cpp
+++ b/Sources/Client/DemoPlayer.cpp
@@ -1,0 +1,252 @@
+/*
+ Copyright (c) 2013 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#include "DemoPlayer.h"
+#include <Core/Debug.h>
+
+namespace spades {
+	namespace client {
+
+		DemoPlayer::DemoPlayer()
+		    : isOpen(false),
+		      paused(false),
+		      finished(false),
+		      protocolVersion(0),
+		      playbackTime(0.0f),
+		      duration(0.0f),
+		      speed(1.0f),
+		      currentPacketIndex(0) {}
+
+		DemoPlayer::~DemoPlayer() {
+			Close();
+		}
+
+		bool DemoPlayer::Open(const std::string& fname) {
+			SPADES_MARK_FUNCTION();
+
+			Close();
+
+			file.open(fname, std::ios::binary | std::ios::in);
+			if (!file.is_open()) {
+				SPLog("Failed to open demo file: %s", fname.c_str());
+				return false;
+			}
+
+			filename = fname;
+
+			if (!ReadHeader()) {
+				file.close();
+				return false;
+			}
+
+			if (!PreloadPackets()) {
+				file.close();
+				return false;
+			}
+
+			isOpen = true;
+			paused = false;
+			finished = false;
+			playbackTime = 0.0f;
+			currentPacketIndex = 0;
+
+			SPLog("Opened demo file: %s (protocol %d, %.1f seconds, %zu packets)",
+			      filename.c_str(), protocolVersion, duration, packets.size());
+
+			return true;
+		}
+
+		void DemoPlayer::Close() {
+			SPADES_MARK_FUNCTION();
+
+			if (file.is_open())
+				file.close();
+
+			isOpen = false;
+			paused = false;
+			finished = false;
+			playbackTime = 0.0f;
+			duration = 0.0f;
+			currentPacketIndex = 0;
+			packets.clear();
+			filename.clear();
+		}
+
+		bool DemoPlayer::ReadHeader() {
+			SPADES_MARK_FUNCTION();
+
+			uint8_t header[2];
+			file.read(reinterpret_cast<char*>(header), 2);
+
+			if (!file.good() || file.gcount() != 2) {
+				SPLog("Failed to read demo header");
+				return false;
+			}
+
+			if (header[0] != FILE_VERSION) {
+				SPLog("Unsupported demo file version: %d (expected %d)",
+				      header[0], FILE_VERSION);
+				return false;
+			}
+
+			protocolVersion = header[1];
+			if (protocolVersion != 3 && protocolVersion != 4) {
+				SPLog("Unsupported protocol version: %d", protocolVersion);
+				return false;
+			}
+
+			return true;
+		}
+
+		bool DemoPlayer::PreloadPackets() {
+			SPADES_MARK_FUNCTION();
+
+			packets.clear();
+			duration = 0.0f;
+
+			while (file.good() && !file.eof()) {
+				float timestamp;
+				file.read(reinterpret_cast<char*>(&timestamp), sizeof(float));
+				if (!file.good() || file.gcount() != sizeof(float))
+					break;
+
+				uint16_t length;
+				file.read(reinterpret_cast<char*>(&length), sizeof(uint16_t));
+				if (!file.good() || file.gcount() != sizeof(uint16_t))
+					break;
+
+				if (length == 0 || length > 65535) {
+					SPLog("Invalid packet length: %u", length);
+					break;
+				}
+
+				DemoPacket packet;
+				packet.timestamp = timestamp;
+				packet.data.resize(length);
+				file.read(packet.data.data(), length);
+
+				if (!file.good() || file.gcount() != length)
+					break;
+
+				packets.push_back(std::move(packet));
+				duration = timestamp;
+			}
+
+			if (packets.empty()) {
+				SPLog("No packets found in demo file");
+				return false;
+			}
+
+			return true;
+		}
+
+		int DemoPlayer::Update(float dt, const PacketHandler& handler) {
+			if (!isOpen || finished || paused)
+				return 0;
+
+			playbackTime += dt * speed;
+
+			int dispatched = 0;
+			while (currentPacketIndex < packets.size()) {
+				const auto& packet = packets[currentPacketIndex];
+				if (packet.timestamp > playbackTime)
+					break;
+
+				handler(packet.data);
+				currentPacketIndex++;
+				dispatched++;
+			}
+
+			if (currentPacketIndex >= packets.size())
+				finished = true;
+
+			return dispatched;
+		}
+
+		void DemoPlayer::Seek(float time) {
+			if (!isOpen)
+				return;
+
+			playbackTime = std::max(0.0f, std::min(time, duration));
+			finished = false;
+
+			// Find the packet index for the new time
+			currentPacketIndex = 0;
+			for (size_t i = 0; i < packets.size(); i++) {
+				if (packets[i].timestamp > playbackTime)
+					break;
+				currentPacketIndex = i;
+			}
+		}
+
+		void DemoPlayer::FastForward(float seconds) {
+			Seek(playbackTime + seconds);
+		}
+
+		void DemoPlayer::Pause() {
+			paused = true;
+		}
+
+		void DemoPlayer::Resume() {
+			paused = false;
+		}
+
+		void DemoPlayer::TogglePause() {
+			paused = !paused;
+		}
+
+		void DemoPlayer::SetSpeed(float s) {
+			speed = std::max(0.1f, std::min(s, 10.0f));
+		}
+
+		const std::vector<char>& DemoPlayer::GetPacket(size_t index) const {
+			static std::vector<char> empty;
+			if (index >= packets.size())
+				return empty;
+			return packets[index].data;
+		}
+
+		void DemoPlayer::Reset() {
+			if (!isOpen)
+				return;
+			playbackTime = 0.0f;
+			currentPacketIndex = 0;
+			finished = false;
+			paused = false;
+		}
+
+		const std::vector<char>& DemoPlayer::PeekNextPacket() const {
+			static std::vector<char> empty;
+			if (!isOpen || currentPacketIndex >= packets.size())
+				return empty;
+			return packets[currentPacketIndex].data;
+		}
+
+		void DemoPlayer::AdvancePacket() {
+			if (!isOpen)
+				return;
+			if (currentPacketIndex < packets.size())
+				currentPacketIndex++;
+			if (currentPacketIndex >= packets.size())
+				finished = true;
+		}
+
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/DemoPlayer.cpp
+++ b/Sources/Client/DemoPlayer.cpp
@@ -223,6 +223,12 @@ namespace spades {
 			return packets[index].data;
 		}
 
+		float DemoPlayer::GetPacketTimestamp(size_t index) const {
+			if (index >= packets.size())
+				return 0.0f;
+			return packets[index].timestamp;
+		}
+
 		void DemoPlayer::Reset() {
 			if (!isOpen)
 				return;

--- a/Sources/Client/DemoPlayer.cpp
+++ b/Sources/Client/DemoPlayer.cpp
@@ -154,6 +154,9 @@ namespace spades {
 				return false;
 			}
 
+			// All data is preloaded; release the file handle.
+			file.close();
+
 			return true;
 		}
 

--- a/Sources/Client/DemoPlayer.cpp
+++ b/Sources/Client/DemoPlayer.cpp
@@ -220,17 +220,11 @@ namespace spades {
 			speed = std::max(0.1f, std::min(s, 10.0f));
 		}
 
-		const std::vector<char>& DemoPlayer::GetPacket(size_t index) const {
-			static std::vector<char> empty;
-			if (index >= packets.size())
-				return empty;
-			return packets[index].data;
-		}
-
-		float DemoPlayer::GetPacketTimestamp(size_t index) const {
-			if (index >= packets.size())
-				return 0.0f;
-			return packets[index].timestamp;
+		void DemoPlayer::ReplayUpTo(float targetTime, const PacketHandler& handler) const {
+			auto end = std::upper_bound(packets.begin(), packets.end(), targetTime,
+			    [](float t, const DemoPacket& p) { return t < p.timestamp; });
+			for (auto it = packets.begin(); it != end; ++it)
+				handler(it->data);
 		}
 
 		void DemoPlayer::Reset() {

--- a/Sources/Client/DemoPlayer.cpp
+++ b/Sources/Client/DemoPlayer.cpp
@@ -18,6 +18,8 @@
 
  */
 
+#include <algorithm>
+
 #include "DemoPlayer.h"
 #include <Core/Debug.h>
 
@@ -190,13 +192,12 @@ namespace spades {
 			playbackTime = std::max(0.0f, std::min(time, duration));
 			finished = false;
 
-			// Find the packet index for the new time
-			currentPacketIndex = 0;
-			for (size_t i = 0; i < packets.size(); i++) {
-				if (packets[i].timestamp > playbackTime)
-					break;
-				currentPacketIndex = i;
-			}
+			// Find the first packet with timestamp > playbackTime (O(log n)).
+			// Update() will start dispatching from this index, so no packet
+			// at or before the seek point gets re-dispatched.
+			auto it = std::upper_bound(packets.begin(), packets.end(), playbackTime,
+			    [](float t, const DemoPacket& p) { return t < p.timestamp; });
+			currentPacketIndex = static_cast<size_t>(std::distance(packets.begin(), it));
 		}
 
 		void DemoPlayer::FastForward(float seconds) {

--- a/Sources/Client/DemoPlayer.cpp
+++ b/Sources/Client/DemoPlayer.cpp
@@ -238,21 +238,5 @@ namespace spades {
 			paused = false;
 		}
 
-		const std::vector<char>& DemoPlayer::PeekNextPacket() const {
-			static std::vector<char> empty;
-			if (!isOpen || currentPacketIndex >= packets.size())
-				return empty;
-			return packets[currentPacketIndex].data;
-		}
-
-		void DemoPlayer::AdvancePacket() {
-			if (!isOpen)
-				return;
-			if (currentPacketIndex < packets.size())
-				currentPacketIndex++;
-			if (currentPacketIndex >= packets.size())
-				finished = true;
-		}
-
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/DemoPlayer.cpp
+++ b/Sources/Client/DemoPlayer.cpp
@@ -220,11 +220,15 @@ namespace spades {
 			speed = std::max(0.1f, std::min(s, 10.0f));
 		}
 
-		void DemoPlayer::ReplayUpTo(float targetTime, const PacketHandler& handler) const {
+		void DemoPlayer::ReplayUpTo(float targetTime, const TimedPacketHandler& handler) const {
 			auto end = std::upper_bound(packets.begin(), packets.end(), targetTime,
 			    [](float t, const DemoPacket& p) { return t < p.timestamp; });
-			for (auto it = packets.begin(); it != end; ++it)
-				handler(it->data);
+			float prev = 0.0f;
+			for (auto it = packets.begin(); it != end; ++it) {
+				float dt = std::max(0.0f, it->timestamp - prev);
+				handler(it->data, dt);
+				prev = it->timestamp;
+			}
 		}
 
 		void DemoPlayer::Reset() {

--- a/Sources/Client/DemoPlayer.cpp
+++ b/Sources/Client/DemoPlayer.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 
 #include "DemoPlayer.h"
+#include "NetProtocol.h"
 #include <Core/Debug.h>
 
 namespace spades {
@@ -34,6 +35,7 @@ namespace spades {
 		      playbackTime(0.0f),
 		      duration(0.0f),
 		      speed(1.0f),
+		      bootstrapEndTime(0.0f),
 		      currentPacketIndex(0) {}
 
 		DemoPlayer::~DemoPlayer() {
@@ -86,6 +88,7 @@ namespace spades {
 			finished = false;
 			playbackTime = 0.0f;
 			duration = 0.0f;
+			bootstrapEndTime = 0.0f;
 			currentPacketIndex = 0;
 			packets.clear();
 			filename.clear();
@@ -156,6 +159,26 @@ namespace spades {
 				return false;
 			}
 
+			// Identify the prefix that constitutes the initial-state stream so
+			// backward seeks can clamp to it: the recorder writes MapStart,
+			// MapChunk, StateData and ExistingPlayer back-to-back at the very
+			// start of a demo, each timestamped with the running stopwatch (so
+			// strictly > 0). Without this clamp, Seek(0) would land before the
+			// bootstrap and leave the world in an empty state on rebuild.
+			bootstrapEndTime = 0.0f;
+			for (const auto& pkt : packets) {
+				if (pkt.data.empty())
+					break;
+				uint8_t type = static_cast<uint8_t>(pkt.data[0]);
+				if (type != PacketTypeMapStart
+				 && type != PacketTypeMapChunk
+				 && type != PacketTypeStateData
+				 && type != PacketTypeExistingPlayer) {
+					break;
+				}
+				bootstrapEndTime = pkt.timestamp;
+			}
+
 			// All data is preloaded; release the file handle.
 			file.close();
 
@@ -188,6 +211,11 @@ namespace spades {
 		void DemoPlayer::Seek(float time) {
 			if (!isOpen)
 				return;
+
+			// Refuse to land before the bootstrap region. Anything earlier
+			// would correspond to an empty world (no map metadata, no game
+			// mode, no players), which is never a valid playback state.
+			time = std::max(time, bootstrapEndTime);
 
 			playbackTime = std::max(0.0f, std::min(time, duration));
 			finished = false;

--- a/Sources/Client/DemoPlayer.cpp
+++ b/Sources/Client/DemoPlayer.cpp
@@ -1,20 +1,21 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2026 Francois ND
+ based on code of OpenSpades (c) yvt 2013.
 
- This file is part of OpenSpades.
+ This file is part of ZeroSpades, a fork of OpenSpades.
 
- OpenSpades is free software: you can redistribute it and/or modify
+ ZeroSpades is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- OpenSpades is distributed in the hope that it will be useful,
+ ZeroSpades is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
 

--- a/Sources/Client/DemoPlayer.h
+++ b/Sources/Client/DemoPlayer.h
@@ -1,0 +1,216 @@
+/*
+ Copyright (c) 2013 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <Core/Stopwatch.h>
+
+namespace spades {
+	namespace client {
+
+		/**
+		 * Plays back demo files recorded in aos_replay compatible format.
+		 *
+		 * File format:
+		 * - Header: 2 bytes
+		 *   - Byte 0: File version (1)
+		 *   - Byte 1: Protocol version (3 for 0.75, 4 for 0.76)
+		 * - Packets: variable length entries
+		 *   - 4 bytes: timestamp (float, seconds since recording start)
+		 *   - 2 bytes: packet length (uint16)
+		 *   - N bytes: packet data
+		 */
+		class DemoPlayer {
+		public:
+			static constexpr uint8_t FILE_VERSION = 1;
+
+			using PacketHandler = std::function<void(const std::vector<char>&)>;
+
+			DemoPlayer();
+			~DemoPlayer();
+
+			/**
+			 * Opens a demo file for playback.
+			 * @param filename Path to the demo file
+			 * @return true if the file was opened successfully
+			 */
+			bool Open(const std::string& filename);
+
+			/**
+			 * Closes the current demo file.
+			 */
+			void Close();
+
+			/**
+			 * Updates playback and dispatches packets that should be played.
+			 * @param dt Delta time since last update
+			 * @param handler Callback for each packet to be played
+			 * @return Number of packets dispatched
+			 */
+			int Update(float dt, const PacketHandler& handler);
+
+			/**
+			 * Seeks to a specific time in the demo.
+			 * @param time Time in seconds from the start
+			 */
+			void Seek(float time);
+
+			/**
+			 * Fast-forward by a number of seconds.
+			 * @param seconds Seconds to skip forward
+			 */
+			void FastForward(float seconds);
+
+			/**
+			 * Pauses playback.
+			 */
+			void Pause();
+
+			/**
+			 * Resumes playback.
+			 */
+			void Resume();
+
+			/**
+			 * Toggles pause state.
+			 */
+			void TogglePause();
+
+			/**
+			 * Sets the playback speed multiplier.
+			 * @param speed Speed multiplier (1.0 = normal, 2.0 = double speed)
+			 */
+			void SetSpeed(float speed);
+
+			/**
+			 * @return true if a demo is currently loaded
+			 */
+			bool IsOpen() const { return isOpen; }
+
+			/**
+			 * @return true if playback is paused
+			 */
+			bool IsPaused() const { return paused; }
+
+			/**
+			 * @return true if playback has finished
+			 */
+			bool IsFinished() const { return finished; }
+
+			/**
+			 * @return Current playback time in seconds
+			 */
+			float GetTime() const { return playbackTime; }
+
+			/**
+			 * @return Total demo duration in seconds (approximate)
+			 */
+			float GetDuration() const { return duration; }
+
+			/**
+			 * @return Protocol version of the demo (3 for 0.75, 4 for 0.76)
+			 */
+			int GetProtocolVersion() const { return protocolVersion; }
+
+			/**
+			 * @return Current playback speed multiplier
+			 */
+			float GetSpeed() const { return speed; }
+
+			/**
+			 * @return The filename of the loaded demo
+			 */
+			const std::string& GetFilename() const { return filename; }
+
+			/**
+			 * @return Total number of packets in the demo
+			 */
+			size_t GetPacketCount() const { return packets.size(); }
+
+			/**
+			 * @return Current packet index
+			 */
+			size_t GetCurrentPacketIndex() const { return currentPacketIndex; }
+
+			/**
+			 * Gets a packet by index.
+			 * @param index Packet index
+			 * @return Packet data, or empty vector if index is out of range
+			 */
+			const std::vector<char>& GetPacket(size_t index) const;
+
+			/**
+			 * Resets playback to the beginning.
+			 */
+			void Reset();
+
+			/**
+			 * Gets the next packet without advancing time (for initial loading).
+			 * @return Packet data, or empty vector if no more packets
+			 */
+			const std::vector<char>& PeekNextPacket() const;
+
+			/**
+			 * Advances to the next packet (for initial loading).
+			 */
+			void AdvancePacket();
+
+		private:
+			struct DemoPacket {
+				float timestamp;
+				std::vector<char> data;
+			};
+
+			std::ifstream file;
+			std::string filename;
+			bool isOpen;
+			bool paused;
+			bool finished;
+			int protocolVersion;
+			float playbackTime;
+			float duration;
+			float speed;
+
+			// Pre-loaded packets for seeking
+			std::vector<DemoPacket> packets;
+			size_t currentPacketIndex;
+
+			/**
+			 * Reads the file header and validates it.
+			 * @return true if the header is valid
+			 */
+			bool ReadHeader();
+
+			/**
+			 * Pre-loads all packets from the file for seeking support.
+			 * @return true if successful
+			 */
+			bool PreloadPackets();
+		};
+
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/DemoPlayer.h
+++ b/Sources/Client/DemoPlayer.h
@@ -147,28 +147,18 @@ namespace spades {
 			const std::string& GetFilename() const { return filename; }
 
 			/**
-			 * @return Total number of packets in the demo
-			 */
-			size_t GetPacketCount() const { return packets.size(); }
-
-			/**
 			 * @return Current packet index
 			 */
 			size_t GetCurrentPacketIndex() const { return currentPacketIndex; }
 
 			/**
-			 * Gets a packet by index.
-			 * @param index Packet index
-			 * @return Packet data, or empty vector if index is out of range
+			 * Calls handler for every packet whose timestamp is <= targetTime, in order.
+			 * Does NOT modify playbackTime, currentPacketIndex, or paused state; safe to
+			 * call during a backward-seek reset without disrupting normal playback state.
+			 * @param targetTime Upper bound (inclusive) on packet timestamps to replay
+			 * @param handler    Callback invoked for each matching packet
 			 */
-			const std::vector<char>& GetPacket(size_t index) const;
-
-			/**
-			 * Gets the timestamp of a packet by index.
-			 * @param index Packet index
-			 * @return Timestamp in seconds, or 0 if index is out of range
-			 */
-			float GetPacketTimestamp(size_t index) const;
+			void ReplayUpTo(float targetTime, const PacketHandler& handler) const;
 
 			/**
 			 * Resets playback to the beginning.

--- a/Sources/Client/DemoPlayer.h
+++ b/Sources/Client/DemoPlayer.h
@@ -164,6 +164,13 @@ namespace spades {
 			const std::vector<char>& GetPacket(size_t index) const;
 
 			/**
+			 * Gets the timestamp of a packet by index.
+			 * @param index Packet index
+			 * @return Timestamp in seconds, or 0 if index is out of range
+			 */
+			float GetPacketTimestamp(size_t index) const;
+
+			/**
 			 * Resets playback to the beginning.
 			 */
 			void Reset();

--- a/Sources/Client/DemoPlayer.h
+++ b/Sources/Client/DemoPlayer.h
@@ -175,17 +175,6 @@ namespace spades {
 			 */
 			void Reset();
 
-			/**
-			 * Gets the next packet without advancing time (for initial loading).
-			 * @return Packet data, or empty vector if no more packets
-			 */
-			const std::vector<char>& PeekNextPacket() const;
-
-			/**
-			 * Advances to the next packet (for initial loading).
-			 */
-			void AdvancePacket();
-
 		private:
 			struct DemoPacket {
 				float timestamp;

--- a/Sources/Client/DemoPlayer.h
+++ b/Sources/Client/DemoPlayer.h
@@ -153,6 +153,19 @@ namespace spades {
 			size_t GetCurrentPacketIndex() const { return currentPacketIndex; }
 
 			/**
+			 * Timestamp of the last packet that is part of the initial-state stream
+			 * (MapStart / MapChunk / StateData / ExistingPlayer). These packets are
+			 * written by the recorder immediately after the stopwatch starts, so
+			 * they always carry tiny but strictly positive timestamps; seek logic
+			 * uses this value to ensure they are always re-applied when rebuilding
+			 * the world.
+			 *
+			 * @return Bootstrap-end timestamp in seconds, or 0 if there is no
+			 *         identifiable bootstrap prefix.
+			 */
+			float GetBootstrapEndTime() const { return bootstrapEndTime; }
+
+			/**
 			 * Calls handler for every packet whose timestamp is <= targetTime, in order.
 			 * The handler also receives the time delta from the previous packet (or 0
 			 * for the first), so callers can age the world in step with playback time
@@ -184,6 +197,7 @@ namespace spades {
 			float playbackTime;
 			float duration;
 			float speed;
+			float bootstrapEndTime;
 
 			// Pre-loaded packets for seeking
 			std::vector<DemoPacket> packets;

--- a/Sources/Client/DemoPlayer.h
+++ b/Sources/Client/DemoPlayer.h
@@ -49,6 +49,7 @@ namespace spades {
 			static constexpr uint8_t FILE_VERSION = 1;
 
 			using PacketHandler = std::function<void(const std::vector<char>&)>;
+			using TimedPacketHandler = std::function<void(const std::vector<char>&, float dt)>;
 
 			DemoPlayer();
 			~DemoPlayer();
@@ -153,12 +154,15 @@ namespace spades {
 
 			/**
 			 * Calls handler for every packet whose timestamp is <= targetTime, in order.
+			 * The handler also receives the time delta from the previous packet (or 0
+			 * for the first), so callers can age the world in step with playback time
+			 * (e.g. to fire grenade fuses silently during a forward seek).
 			 * Does NOT modify playbackTime, currentPacketIndex, or paused state; safe to
 			 * call during a backward-seek reset without disrupting normal playback state.
 			 * @param targetTime Upper bound (inclusive) on packet timestamps to replay
-			 * @param handler    Callback invoked for each matching packet
+			 * @param handler    Callback invoked for each matching packet, with dt
 			 */
-			void ReplayUpTo(float targetTime, const PacketHandler& handler) const;
+			void ReplayUpTo(float targetTime, const TimedPacketHandler& handler) const;
 
 			/**
 			 * Resets playback to the beginning.

--- a/Sources/Client/DemoPlayer.h
+++ b/Sources/Client/DemoPlayer.h
@@ -1,20 +1,21 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2026 Francois ND
+ based on code of OpenSpades (c) yvt 2013.
 
- This file is part of OpenSpades.
+ This file is part of ZeroSpades, a fork of OpenSpades.
 
- OpenSpades is free software: you can redistribute it and/or modify
+ ZeroSpades is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- OpenSpades is distributed in the hope that it will be useful,
+ ZeroSpades is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
 

--- a/Sources/Client/DemoRecorder.cpp
+++ b/Sources/Client/DemoRecorder.cpp
@@ -1,0 +1,148 @@
+/*
+ Copyright (c) 2013 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#define MKDIR(path) _mkdir(path)
+#else
+#define MKDIR(path) mkdir(path, 0755)
+#endif
+
+#include "DemoRecorder.h"
+#include <Core/Debug.h>
+
+namespace spades {
+	namespace client {
+
+		DemoRecorder::DemoRecorder()
+		    : recording(false), packetCount(0), fileSize(0) {}
+
+		DemoRecorder::~DemoRecorder() {
+			if (recording)
+				StopRecording();
+		}
+
+		bool DemoRecorder::StartRecording(const std::string& fname, int protocolVersion) {
+			SPADES_MARK_FUNCTION();
+
+			if (recording) {
+				SPLog("Already recording, stopping previous recording");
+				StopRecording();
+			}
+
+			filename = fname;
+
+			file.open(filename, std::ios::binary | std::ios::out);
+			if (!file.is_open()) {
+				SPLog("Failed to open demo file for writing: %s", filename.c_str());
+				return false;
+			}
+
+			// Write header: file version and protocol version
+			uint8_t header[2];
+			header[0] = FILE_VERSION;
+			header[1] = static_cast<uint8_t>(protocolVersion);
+			file.write(reinterpret_cast<const char*>(header), 2);
+
+			if (!file.good()) {
+				SPLog("Failed to write demo header");
+				file.close();
+				return false;
+			}
+
+			fileSize = 2;
+			packetCount = 0;
+			stopwatch.Reset();
+			recording = true;
+
+			SPLog("Started demo recording: %s (protocol version %d)", filename.c_str(), protocolVersion);
+			return true;
+		}
+
+		void DemoRecorder::StopRecording() {
+			SPADES_MARK_FUNCTION();
+
+			if (!recording)
+				return;
+
+			file.flush();
+			file.close();
+			recording = false;
+
+			SPLog("Stopped demo recording: %s (%llu packets, %llu bytes, %.1f seconds)",
+			      filename.c_str(), (unsigned long long)packetCount,
+			      (unsigned long long)fileSize, GetRecordingTime());
+		}
+
+		void DemoRecorder::RecordPacket(const char* data, size_t length) {
+			SPADES_MARK_FUNCTION_DEBUG();
+
+			if (!recording || length == 0 || length > 65535)
+				return;
+
+			// Write timestamp (4 bytes, float)
+			float timestamp = static_cast<float>(stopwatch.GetTime());
+			file.write(reinterpret_cast<const char*>(&timestamp), sizeof(float));
+
+			// Write packet length (2 bytes, uint16)
+			uint16_t len = static_cast<uint16_t>(length);
+			file.write(reinterpret_cast<const char*>(&len), sizeof(uint16_t));
+
+			// Write packet data
+			file.write(data, length);
+
+			if (file.good()) {
+				packetCount++;
+				fileSize += sizeof(float) + sizeof(uint16_t) + length;
+			} else {
+				SPLog("Failed to write packet to demo file");
+			}
+		}
+
+		float DemoRecorder::GetRecordingTime() const {
+			if (!recording)
+				return 0.0f;
+			return static_cast<float>(const_cast<Stopwatch&>(stopwatch).GetTime());
+		}
+
+		std::string DemoRecorder::GenerateFilename() {
+			auto now = std::chrono::system_clock::now();
+			auto time = std::chrono::system_clock::to_time_t(now);
+			auto tm = std::localtime(&time);
+
+			std::ostringstream oss;
+			oss << "Demos/demo_"
+			    << std::put_time(tm, "%Y%m%d_%H%M%S")
+			    << ".dem";
+
+			// Ensure the Demos directory exists
+			MKDIR("Demos");
+
+			return oss.str();
+		}
+
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/DemoRecorder.cpp
+++ b/Sources/Client/DemoRecorder.cpp
@@ -42,6 +42,16 @@
 namespace spades {
 	namespace client {
 
+		static std::string s_baseDir;
+
+		void DemoRecorder::SetBaseDirectory(const std::string& dir) {
+			s_baseDir = dir;
+		}
+
+		std::string DemoRecorder::GetDemosDirectory() {
+			return s_baseDir.empty() ? "Demos" : s_baseDir + "/Demos";
+		}
+
 		DemoRecorder::DemoRecorder()
 		    : recording(false), packetCount(0), fileSize(0) {}
 
@@ -152,38 +162,41 @@ namespace spades {
 			auto time = std::chrono::system_clock::to_time_t(now);
 			auto tm = std::localtime(&time);
 
+			std::string demosDir = GetDemosDirectory();
+
+			// Ensure the Demos directory exists
+			MKDIR(demosDir.c_str());
+
 			std::ostringstream oss;
-			oss << "Demos/" << std::put_time(tm, "%Y-%m-%d-%H-%M");
+			oss << demosDir << "/" << std::put_time(tm, "%Y-%m-%d-%H-%M");
 			if (!context.empty())
 				oss << "-" << context;
 			oss << ".dem";
-
-			// Ensure the Demos directory exists
-			MKDIR("Demos");
 
 			return oss.str();
 		}
 
 		static std::vector<std::string> ScanDemosDir() {
+			std::string demosDir = DemoRecorder::GetDemosDirectory();
 			std::vector<std::string> files;
 #ifdef _WIN32
 			WIN32_FIND_DATAA fd;
-			HANDLE hFind = FindFirstFileA("Demos\\*.dem", &fd);
+			HANDLE hFind = FindFirstFileA((demosDir + "\\*.dem").c_str(), &fd);
 			if (hFind != INVALID_HANDLE_VALUE) {
 				do {
 					if (!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
-						files.push_back(std::string("Demos/") + fd.cFileName);
+						files.push_back(demosDir + "/" + fd.cFileName);
 				} while (FindNextFileA(hFind, &fd));
 				FindClose(hFind);
 			}
 #else
-			DIR* dir = opendir("Demos");
+			DIR* dir = opendir(demosDir.c_str());
 			if (dir) {
 				struct dirent* entry;
 				while ((entry = readdir(dir)) != nullptr) {
 					std::string name = entry->d_name;
 					if (name.size() > 4 && name.substr(name.size() - 4) == ".dem")
-						files.push_back(std::string("Demos/") + name);
+						files.push_back(demosDir + "/" + name);
 				}
 				closedir(dir);
 			}

--- a/Sources/Client/DemoRecorder.cpp
+++ b/Sources/Client/DemoRecorder.cpp
@@ -140,7 +140,7 @@ namespace spades {
 		float DemoRecorder::GetRecordingTime() const {
 			if (!recording)
 				return 0.0f;
-			return static_cast<float>(const_cast<Stopwatch&>(stopwatch).GetTime());
+			return static_cast<float>(stopwatch.GetTime());
 		}
 
 		std::string DemoRecorder::SanitizeComponent(const std::string& s) {

--- a/Sources/Client/DemoRecorder.cpp
+++ b/Sources/Client/DemoRecorder.cpp
@@ -53,7 +53,7 @@ namespace spades {
 		}
 
 		DemoRecorder::DemoRecorder()
-		    : recording(false), packetCount(0), fileSize(0) {}
+		    : recording(false), packetCount(0) {}
 
 		DemoRecorder::~DemoRecorder() {
 			if (recording)
@@ -88,7 +88,6 @@ namespace spades {
 				return false;
 			}
 
-			fileSize = 2;
 			packetCount = 0;
 			stopwatch.Reset();
 			recording = true;
@@ -109,7 +108,7 @@ namespace spades {
 
 			SPLog("Stopped demo recording: %s (%llu packets, %llu bytes, %.1f seconds)",
 			      filename.c_str(), (unsigned long long)packetCount,
-			      (unsigned long long)fileSize, GetRecordingTime());
+			      (unsigned long long)file.tellp(), GetRecordingTime());
 		}
 
 		void DemoRecorder::RecordPacket(const char* data, size_t length) {
@@ -131,7 +130,6 @@ namespace spades {
 
 			if (file.good()) {
 				packetCount++;
-				fileSize += sizeof(float) + sizeof(uint16_t) + length;
 			} else {
 				SPLog("Failed to write packet to demo file");
 			}

--- a/Sources/Client/DemoRecorder.cpp
+++ b/Sources/Client/DemoRecorder.cpp
@@ -18,16 +18,21 @@
 
  */
 
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
+#include <string>
+#include <vector>
 #include <sys/stat.h>
 
 #ifdef _WIN32
 #include <direct.h>
+#include <windows.h>
 #define MKDIR(path) _mkdir(path)
 #else
+#include <dirent.h>
 #define MKDIR(path) mkdir(path, 0755)
 #endif
 
@@ -128,20 +133,70 @@ namespace spades {
 			return static_cast<float>(const_cast<Stopwatch&>(stopwatch).GetTime());
 		}
 
-		std::string DemoRecorder::GenerateFilename() {
+		std::string DemoRecorder::GenerateFilename(const std::string& context) {
 			auto now = std::chrono::system_clock::now();
 			auto time = std::chrono::system_clock::to_time_t(now);
 			auto tm = std::localtime(&time);
 
 			std::ostringstream oss;
-			oss << "Demos/demo_"
-			    << std::put_time(tm, "%Y%m%d_%H%M%S")
-			    << ".dem";
+			oss << "Demos/" << std::put_time(tm, "%Y%m%d_%H%M%S");
+			if (!context.empty()) {
+				oss << "_" << context;
+			}
+			oss << ".dem";
 
 			// Ensure the Demos directory exists
 			MKDIR("Demos");
 
 			return oss.str();
+		}
+
+		static std::vector<std::string> ScanDemosDir() {
+			std::vector<std::string> files;
+#ifdef _WIN32
+			WIN32_FIND_DATAA fd;
+			HANDLE hFind = FindFirstFileA("Demos\\*.dem", &fd);
+			if (hFind != INVALID_HANDLE_VALUE) {
+				do {
+					if (!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+						files.push_back(std::string("Demos/") + fd.cFileName);
+				} while (FindNextFileA(hFind, &fd));
+				FindClose(hFind);
+			}
+#else
+			DIR* dir = opendir("Demos");
+			if (dir) {
+				struct dirent* entry;
+				while ((entry = readdir(dir)) != nullptr) {
+					std::string name = entry->d_name;
+					if (name.size() > 4 && name.substr(name.size() - 4) == ".dem")
+						files.push_back(std::string("Demos/") + name);
+				}
+				closedir(dir);
+			}
+#endif
+			std::sort(files.begin(), files.end());
+			return files;
+		}
+
+		std::vector<std::string> DemoRecorder::ListRecordings() {
+			return ScanDemosDir();
+		}
+
+		void DemoRecorder::PruneOldRecordings(size_t maxCount) {
+			std::vector<std::string> files = ScanDemosDir();
+
+			if (files.size() <= maxCount)
+				return;
+
+			size_t toRemove = files.size() - maxCount;
+			for (size_t i = 0; i < toRemove; i++) {
+				if (remove(files[i].c_str()) == 0) {
+					SPLog("Pruned old demo recording: %s", files[i].c_str());
+				} else {
+					SPLog("Failed to prune demo recording: %s", files[i].c_str());
+				}
+			}
 		}
 
 	} // namespace client

--- a/Sources/Client/DemoRecorder.cpp
+++ b/Sources/Client/DemoRecorder.cpp
@@ -133,16 +133,29 @@ namespace spades {
 			return static_cast<float>(const_cast<Stopwatch&>(stopwatch).GetTime());
 		}
 
+		std::string DemoRecorder::SanitizeComponent(const std::string& s) {
+			std::string out;
+			out.reserve(s.size());
+			for (unsigned char c : s) {
+				if (std::isalnum(c))
+					out += static_cast<char>(std::tolower(c));
+				else if (!out.empty() && out.back() != '_')
+					out += '_';
+			}
+			while (!out.empty() && out.back() == '_')
+				out.pop_back();
+			return out;
+		}
+
 		std::string DemoRecorder::GenerateFilename(const std::string& context) {
 			auto now = std::chrono::system_clock::now();
 			auto time = std::chrono::system_clock::to_time_t(now);
 			auto tm = std::localtime(&time);
 
 			std::ostringstream oss;
-			oss << "Demos/" << std::put_time(tm, "%Y%m%d_%H%M%S");
-			if (!context.empty()) {
-				oss << "_" << context;
-			}
+			oss << "Demos/" << std::put_time(tm, "%Y-%m-%d-%H-%M");
+			if (!context.empty())
+				oss << "-" << context;
 			oss << ".dem";
 
 			// Ensure the Demos directory exists

--- a/Sources/Client/DemoRecorder.cpp
+++ b/Sources/Client/DemoRecorder.cpp
@@ -103,12 +103,14 @@ namespace spades {
 				return;
 
 			file.flush();
+			uint64_t fileSize = static_cast<uint64_t>(file.tellp());
+			float elapsed = GetRecordingTime();
 			file.close();
 			recording = false;
 
 			SPLog("Stopped demo recording: %s (%llu packets, %llu bytes, %.1f seconds)",
 			      filename.c_str(), (unsigned long long)packetCount,
-			      (unsigned long long)file.tellp(), GetRecordingTime());
+			      (unsigned long long)fileSize, elapsed);
 		}
 
 		void DemoRecorder::RecordPacket(const char* data, size_t length) {

--- a/Sources/Client/DemoRecorder.cpp
+++ b/Sources/Client/DemoRecorder.cpp
@@ -1,20 +1,21 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2026 Francois ND
+ based on code of OpenSpades (c) yvt 2013.
 
- This file is part of OpenSpades.
+ This file is part of ZeroSpades, a fork of OpenSpades.
 
- OpenSpades is free software: you can redistribute it and/or modify
+ ZeroSpades is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- OpenSpades is distributed in the hope that it will be useful,
+ ZeroSpades is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
 

--- a/Sources/Client/DemoRecorder.h
+++ b/Sources/Client/DemoRecorder.h
@@ -1,0 +1,113 @@
+/*
+ Copyright (c) 2013 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <string>
+
+#include <Core/Stopwatch.h>
+
+namespace spades {
+	namespace client {
+
+		/**
+		 * Records gameplay to a demo file compatible with aos_replay format.
+		 *
+		 * File format:
+		 * - Header: 2 bytes
+		 *   - Byte 0: File version (1)
+		 *   - Byte 1: Protocol version (3 for 0.75, 4 for 0.76)
+		 * - Packets: variable length entries
+		 *   - 4 bytes: timestamp (float, seconds since recording start)
+		 *   - 2 bytes: packet length (uint16)
+		 *   - N bytes: packet data
+		 */
+		class DemoRecorder {
+		public:
+			static constexpr uint8_t FILE_VERSION = 1;
+
+			DemoRecorder();
+			~DemoRecorder();
+
+			/**
+			 * Starts recording to a file.
+			 * @param filename Path to the demo file
+			 * @param protocolVersion Protocol version (3 for 0.75, 4 for 0.76)
+			 * @return true if recording started successfully
+			 */
+			bool StartRecording(const std::string& filename, int protocolVersion);
+
+			/**
+			 * Stops recording and closes the file.
+			 */
+			void StopRecording();
+
+			/**
+			 * Records a packet to the demo file.
+			 * @param data Packet data
+			 * @param length Packet length
+			 */
+			void RecordPacket(const char* data, size_t length);
+
+			/**
+			 * @return true if currently recording
+			 */
+			bool IsRecording() const { return recording; }
+
+			/**
+			 * @return Current recording duration in seconds
+			 */
+			float GetRecordingTime() const;
+
+			/**
+			 * @return Number of packets recorded
+			 */
+			uint64_t GetPacketCount() const { return packetCount; }
+
+			/**
+			 * @return Current file size in bytes
+			 */
+			uint64_t GetFileSize() const { return fileSize; }
+
+			/**
+			 * @return The filename being recorded to
+			 */
+			const std::string& GetFilename() const { return filename; }
+
+			/**
+			 * Generates a unique filename for a new demo.
+			 * Format: demo_YYYYMMDD_HHMMSS.dem
+			 */
+			static std::string GenerateFilename();
+
+		private:
+			std::ofstream file;
+			Stopwatch stopwatch;
+			bool recording;
+			std::string filename;
+			uint64_t packetCount;
+			uint64_t fileSize;
+		};
+
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/DemoRecorder.h
+++ b/Sources/Client/DemoRecorder.h
@@ -121,6 +121,16 @@ namespace spades {
 			 */
 			static std::vector<std::string> ListRecordings();
 
+			/**
+			 * Sets the base directory under which the Demos/ subfolder is created.
+			 * Must be called before any recording or listing takes place.
+			 * Defaults to the current working directory if never called.
+			 */
+			static void SetBaseDirectory(const std::string& dir);
+
+			/** Returns the absolute path to the Demos directory. */
+			static std::string GetDemosDirectory();
+
 		private:
 			std::ofstream file;
 			Stopwatch stopwatch;

--- a/Sources/Client/DemoRecorder.h
+++ b/Sources/Client/DemoRecorder.h
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <Core/Stopwatch.h>
 
@@ -95,10 +96,22 @@ namespace spades {
 			const std::string& GetFilename() const { return filename; }
 
 			/**
-			 * Generates a unique filename for a new demo.
-			 * Format: demo_YYYYMMDD_HHMMSS.dem
+			 * Generates a unique filename for a new demo in the Demos/ directory.
+			 * @param context Optional context appended to the filename (e.g. sanitized server address).
+			 *                Format: Demos/YYYYMMDD_HHMMSS[_context].dem
 			 */
-			static std::string GenerateFilename();
+			static std::string GenerateFilename(const std::string& context = "");
+
+			/**
+			 * Removes the oldest .dem files in Demos/ so at most maxCount remain.
+			 * Files are ordered by name (which matches recording order given the timestamp prefix).
+			 */
+			static void PruneOldRecordings(size_t maxCount);
+
+			/**
+			 * Returns a sorted list of .dem file paths found in Demos/.
+			 */
+			static std::vector<std::string> ListRecordings();
 
 		private:
 			std::ofstream file;

--- a/Sources/Client/DemoRecorder.h
+++ b/Sources/Client/DemoRecorder.h
@@ -86,11 +86,6 @@ namespace spades {
 			uint64_t GetPacketCount() const { return packetCount; }
 
 			/**
-			 * @return Current file size in bytes
-			 */
-			uint64_t GetFileSize() const { return fileSize; }
-
-			/**
 			 * @return The filename being recorded to
 			 */
 			const std::string& GetFilename() const { return filename; }
@@ -137,7 +132,6 @@ namespace spades {
 			bool recording;
 			std::string filename;
 			uint64_t packetCount;
-			uint64_t fileSize;
 		};
 
 	} // namespace client

--- a/Sources/Client/DemoRecorder.h
+++ b/Sources/Client/DemoRecorder.h
@@ -96,9 +96,17 @@ namespace spades {
 			const std::string& GetFilename() const { return filename; }
 
 			/**
+			 * Sanitizes a single filename component (map name, server address, etc.).
+			 * Lowercases alphanumeric characters; collapses runs of other characters
+			 * to a single '_'. The '-' separator between components is never emitted.
+			 */
+			static std::string SanitizeComponent(const std::string& s);
+
+			/**
 			 * Generates a unique filename for a new demo in the Demos/ directory.
-			 * @param context Optional context appended to the filename (e.g. sanitized server address).
-			 *                Format: Demos/YYYYMMDD_HHMMSS[_context].dem
+			 * @param context Pre-sanitized context string appended after the timestamp.
+			 *                Individual fields must be joined with '-' by the caller.
+			 *                Format: Demos/YYYY-MM-DD-HH-MM[-context].dem
 			 */
 			static std::string GenerateFilename(const std::string& context = "");
 

--- a/Sources/Client/DemoRecorder.h
+++ b/Sources/Client/DemoRecorder.h
@@ -1,20 +1,21 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2026 Francois ND
+ based on code of OpenSpades (c) yvt 2013.
 
- This file is part of OpenSpades.
+ This file is part of ZeroSpades, a fork of OpenSpades.
 
- OpenSpades is free software: you can redistribute it and/or modify
+ ZeroSpades is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- OpenSpades is distributed in the hope that it will be useful,
+ ZeroSpades is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
 

--- a/Sources/Client/GameMap.cpp
+++ b/Sources/Client/GameMap.cpp
@@ -54,7 +54,7 @@ namespace spades {
 		GameMap::~GameMap() { SPADES_MARK_FUNCTION(); }
 
 		Handle<GameMap> GameMap::Clone() const {
-			Handle<GameMap> copy{new GameMap()};
+			Handle<GameMap> copy{new GameMap(NoInit{})};
 			memcpy(copy->solidMap, solidMap, sizeof(solidMap));
 			memcpy(copy->colorMap, colorMap, sizeof(colorMap));
 			return copy;

--- a/Sources/Client/GameMap.cpp
+++ b/Sources/Client/GameMap.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 
 #include "GameMap.h"
@@ -51,6 +52,13 @@ namespace spades {
 			}
 		}
 		GameMap::~GameMap() { SPADES_MARK_FUNCTION(); }
+
+		Handle<GameMap> GameMap::Clone() const {
+			Handle<GameMap> copy{new GameMap()};
+			memcpy(copy->solidMap, solidMap, sizeof(solidMap));
+			memcpy(copy->colorMap, colorMap, sizeof(colorMap));
+			return copy;
+		}
 
 		void GameMap::AddListener(spades::client::IGameMapListener* l) {
 			std::lock_guard<std::mutex> _guard{listenersMutex};

--- a/Sources/Client/GameMap.h
+++ b/Sources/Client/GameMap.h
@@ -219,6 +219,11 @@ namespace spades {
 				return i;
 			}
 
+			/**
+			 * Returns a new GameMap with identical voxel data but no listeners.
+			 */
+			Handle<GameMap> Clone() const;
+
 		private:
 			uint64_t solidMap[DefaultWidth][DefaultHeight];
 			uint32_t colorMap[DefaultWidth][DefaultHeight][DefaultDepth];

--- a/Sources/Client/GameMap.h
+++ b/Sources/Client/GameMap.h
@@ -225,6 +225,9 @@ namespace spades {
 			Handle<GameMap> Clone() const;
 
 		private:
+			struct NoInit {};
+			explicit GameMap(NoInit) {}
+
 			uint64_t solidMap[DefaultWidth][DefaultHeight];
 			uint32_t colorMap[DefaultWidth][DefaultHeight][DefaultDepth];
 			std::list<IGameMapListener*> listeners;

--- a/Sources/Client/GameProperties.h
+++ b/Sources/Client/GameProperties.h
@@ -65,7 +65,8 @@ namespace spades {
 			 */
 			bool manyPlayers = true;
 
-			int GetMaxNumPlayerSlots() const { return manyPlayers ? 256 : 32; }
+			static constexpr int kMaxPlayerSlots = 256;
+			int GetMaxNumPlayerSlots() const { return manyPlayers ? kMaxPlayerSlots : 32; }
 		};
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/INetClient.h
+++ b/Sources/Client/INetClient.h
@@ -55,7 +55,7 @@ namespace spades {
 			virtual NetClientStatus GetStatus() = 0;
 			virtual std::string GetStatusString() = 0;
 			virtual float GetMapReceivingProgress() = 0;
-			virtual std::shared_ptr<GameProperties>& GetGameProperties() = 0;
+			virtual const std::shared_ptr<GameProperties>& GetGameProperties() = 0;
 
 			// ── Event loop ──────────────────────────────────────────────────
 			// dt is the frame delta-time in seconds. NetClient uses it to pick a poll timeout;

--- a/Sources/Client/INetClient.h
+++ b/Sources/Client/INetClient.h
@@ -89,14 +89,6 @@ namespace spades {
 			virtual void SendTeamChange(int team) = 0;
 			virtual void SendWeaponChange(WeaponType) = 0;
 
-			// ── Demo recording (stubs return false/0/"" in demo mode) ────────
-			virtual bool StartDemoRecording(const std::string& filename = "",
-			                               const std::string& context = "") = 0;
-			virtual void StopDemoRecording() = 0;
-			virtual bool IsDemoRecording() const = 0;
-			virtual float GetDemoRecordingTime() const = 0;
-			virtual uint64_t GetDemoPacketCount() const = 0;
-			virtual const std::string& GetDemoFilename() const = 0;
 		};
 
 	} // namespace client

--- a/Sources/Client/INetClient.h
+++ b/Sources/Client/INetClient.h
@@ -1,0 +1,103 @@
+/*
+ Copyright (c) 2013 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "GameConstants.h"
+#include "Player.h"
+#include <Core/Math.h>
+
+namespace spades {
+	namespace client {
+		struct GameProperties;
+		struct PlayerInput;
+		struct WeaponInput;
+		class Grenade;
+
+		enum NetClientStatus {
+			NetClientStatusNotConnected = 0,
+			NetClientStatusConnecting,
+			NetClientStatusReceivingMap,
+			NetClientStatusConnected
+		};
+
+		/**
+		 * Common interface shared by NetClient (live network) and DemoNetClient (demo playback).
+		 * Client holds a single INetClient* and no longer needs to branch on isDemoMode for any
+		 * method that is present here.
+		 */
+		class INetClient {
+		public:
+			virtual ~INetClient() = default;
+
+			// ── Status ──────────────────────────────────────────────────────
+			virtual NetClientStatus GetStatus() = 0;
+			virtual std::string GetStatusString() = 0;
+			virtual float GetMapReceivingProgress() = 0;
+			virtual std::shared_ptr<GameProperties>& GetGameProperties() = 0;
+
+			// ── Event loop ──────────────────────────────────────────────────
+			// dt is the frame delta-time in seconds. NetClient uses it to pick a poll timeout;
+			// DemoNetClient uses it to advance playback time.
+			virtual void DoEvents(float dt) = 0;
+
+			// ── Network stats (stubs return 0 in demo mode) ─────────────────
+			virtual int GetPing() = 0;
+			virtual float GetPacketLoss() = 0;
+			virtual float GetPacketThrottle() = 0;
+			virtual double GetDownlinkBps() = 0;
+			virtual double GetUplinkBps() = 0;
+
+			// ── Connection ──────────────────────────────────────────────────
+			virtual void Disconnect() = 0;
+
+			// ── Send methods (no-ops in demo mode) ──────────────────────────
+			virtual void SendJoin(int team, WeaponType, std::string name, int score) = 0;
+			virtual void SendPosition(Vector3) = 0;
+			virtual void SendOrientation(Vector3) = 0;
+			virtual void SendPlayerInput(PlayerInput) = 0;
+			virtual void SendWeaponInput(WeaponInput) = 0;
+			virtual void SendHit(int targetPlayerId, HitType) = 0;
+			virtual void SendGrenade(const Grenade&) = 0;
+			virtual void SendTool() = 0;
+			virtual void SendHeldBlockColor() = 0;
+			virtual void SendBlockAction(IntVector3, BlockActionType) = 0;
+			virtual void SendBlockLine(IntVector3 v1, IntVector3 v2) = 0;
+			virtual void SendChat(std::string, bool global) = 0;
+			virtual void SendReload() = 0;
+			virtual void SendTeamChange(int team) = 0;
+			virtual void SendWeaponChange(WeaponType) = 0;
+
+			// ── Demo recording (stubs return false/0/"" in demo mode) ────────
+			virtual bool StartDemoRecording(const std::string& filename = "",
+			                               const std::string& context = "") = 0;
+			virtual void StopDemoRecording() = 0;
+			virtual bool IsDemoRecording() const = 0;
+			virtual float GetDemoRecordingTime() const = 0;
+			virtual uint64_t GetDemoPacketCount() const = 0;
+			virtual const std::string& GetDemoFilename() const = 0;
+		};
+
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/INetClient.h
+++ b/Sources/Client/INetClient.h
@@ -1,20 +1,21 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2026 Francois ND
+ based on code of OpenSpades (c) yvt 2013.
 
- This file is part of OpenSpades.
+ This file is part of ZeroSpades, a fork of OpenSpades.
 
- OpenSpades is free software: you can redistribute it and/or modify
+ ZeroSpades is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- OpenSpades is distributed in the hope that it will be useful,
+ ZeroSpades is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
 

--- a/Sources/Client/MapView.cpp
+++ b/Sources/Client/MapView.cpp
@@ -290,12 +290,12 @@ namespace spades {
 			// The local player (this is important for access control)
 			// In demo mode, there's no local player - treat as spectator
 			stmp::optional<Player&> maybePlayer = world->GetLocalPlayer();
-			bool localPlayerIsSpectator = client->isDemoMode ||
+			bool localPlayerIsSpectator = client->IsDemoMode() ||
 				(maybePlayer && maybePlayer->IsSpectator());
 			bool localPlayerIsSpectating = localPlayerIsSpectator || client->staffSpectating;
 
 			// Need either a local player or demo mode to continue
-			if (!maybePlayer && !client->isDemoMode)
+			if (!maybePlayer && !client->IsDemoMode())
 				return;
 
 			// Pointers for safe access (may be null in demo mode)

--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -327,6 +327,10 @@ namespace spades {
 			return static_cast<float>(peer->packetThrottle) / ENET_PEER_PACKET_THROTTLE_SCALE;
 		}
 
+		void NetClient::DoEvents(float /*dt*/) {
+			DoEvents(status == NetClientStatusConnected ? 0 : 10);
+		}
+
 		void NetClient::DoEvents(int timeout) {
 			SPADES_MARK_FUNCTION();
 

--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -547,10 +547,22 @@ namespace spades {
 					readerOrNone.reset(event.packet);
 					auto& reader = readerOrNone.value();
 
-					// Record packet for demo if recording is active
+					// Record packet for demo if recording is active.
+					// Skip the server's WeaponReload echo for the local player: the
+					// client-sent packet is already recorded in SendReload(), so
+					// recording the server response would produce a double reload.
 					if (demoRecorder && demoRecorder->IsRecording()) {
 						auto data = reader.GetData();
-						demoRecorder->RecordPacket(data.data(), data.size());
+						bool skip = false;
+						if (data.size() >= 2 &&
+						    static_cast<uint8_t>(data[0]) == PacketTypeWeaponReload) {
+							auto localPlayer = GetLocalPlayerOrNull();
+							if (localPlayer &&
+							    static_cast<uint8_t>(data[1]) == static_cast<uint8_t>(localPlayer->GetId()))
+								skip = true;
+						}
+						if (!skip)
+							demoRecorder->RecordPacket(data.data(), data.size());
 					}
 
 					try {

--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -2131,7 +2131,7 @@ namespace spades {
 			SPLog("Initial demo state written successfully");
 		}
 
-		bool NetClient::StartDemoRecording(const std::string& filename) {
+		bool NetClient::StartDemoRecording(const std::string& filename, const std::string& context) {
 			SPADES_MARK_FUNCTION();
 
 			if (!demoRecorder) {
@@ -2144,7 +2144,7 @@ namespace spades {
 				return false;
 			}
 
-			std::string fname = filename.empty() ? DemoRecorder::GenerateFilename() : filename;
+			std::string fname = filename.empty() ? DemoRecorder::GenerateFilename(context) : filename;
 			if (!demoRecorder->StartRecording(fname, protocolVersion))
 				return false;
 

--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -28,6 +28,7 @@
 #include "CTFGameMode.h"
 #include "Client.h"
 #include "GameMap.h"
+#include "NetProtocol.h"
 #include "GameMapLoader.h"
 #include "GameProperties.h"
 #include "Grenade.h"
@@ -59,49 +60,6 @@ namespace spades {
 		namespace {
 			const char UTFSign = -1;
 
-			enum { BLUE_FLAG = 0, GREEN_FLAG = 1, BLUE_BASE = 2, GREEN_BASE = 3 };
-			enum PacketType {
-				PacketTypePositionData = 0,			// C2S2P
-				PacketTypeOrientationData = 1,		// C2S2P
-				PacketTypeWorldUpdate = 2,			// S2C
-				PacketTypeInputData = 3,			// C2S2P
-				PacketTypeWeaponInput = 4,			// C2S2P
-				PacketTypeHitPacket = 5,			// C2S
-				PacketTypeSetHP = 5,				// S2C
-				PacketTypeGrenadePacket = 6,		// C2S2P
-				PacketTypeSetTool = 7,				// C2S2P
-				PacketTypeSetColour = 8,			// C2S2P
-				PacketTypeExistingPlayer = 9,		// C2S2P
-				PacketTypeShortPlayerData = 10,		// S2C
-				PacketTypeMoveObject = 11,			// S2C
-				PacketTypeCreatePlayer = 12,		// S2C
-				PacketTypeBlockAction = 13,			// C2S2P
-				PacketTypeBlockLine = 14,			// C2S2P
-				PacketTypeStateData = 15,			// S2C
-				PacketTypeKillAction = 16,			// S2C
-				PacketTypeChatMessage = 17,			// C2S2P
-				PacketTypeMapStart = 18,			// S2C
-				PacketTypeMapChunk = 19,			// S2C
-				PacketTypePlayerLeft = 20,			// S2P
-				PacketTypeTerritoryCapture = 21,	// S2P
-				PacketTypeProgressBar = 22,			// S2P
-				PacketTypeIntelCapture = 23,		// S2P
-				PacketTypeIntelPickup = 24,			// S2P
-				PacketTypeIntelDrop = 25,			// S2P
-				PacketTypeRestock = 26,				// S2P
-				PacketTypeFogColour = 27,			// S2C
-				PacketTypeWeaponReload = 28,		// C2S2P
-				PacketTypeChangeTeam = 29,			// C2S2P
-				PacketTypeChangeWeapon = 30,		// C2S2P
-				PacketTypeMapCached = 31,			// S2C
-				PacketTypeHandShakeInit = 31,		// S2C
-				PacketTypeHandShakeReturn = 32,		// C2S
-				PacketTypeVersionGet = 33,			// S2C
-				PacketTypeVersionSend = 34,			// C2S
-				PacketTypeExtensionInfo = 60,
-				PacketTypePlayerProperties = 64,
-			};
-
 			enum class VersionInfoPropertyId : std::uint8_t {
 				ApplicationNameAndVersion = 0,
 				UserLocale = 1,
@@ -130,155 +88,7 @@ namespace spades {
 
 				return str;
 			}
-
-			std::string DecodeString(std::string s) {
-				if (s.size() > 0 && s[0] == UTFSign)
-					return s.substr(1);
-
-				return CP437::Decode(s);
-			}
 		} // namespace
-
-		class NetPacketReader {
-			std::vector<char> data;
-			size_t pos;
-
-		public:
-			NetPacketReader(ENetPacket* packet) {
-				SPADES_MARK_FUNCTION();
-
-				data.resize(packet->dataLength);
-				memcpy(data.data(), packet->data, packet->dataLength);
-				enet_packet_destroy(packet);
-				pos = 1;
-			}
-
-			NetPacketReader(const std::vector<char> inData) {
-				data = inData;
-				pos = 1;
-			}
-
-			unsigned int GetTypeRaw() { return static_cast<unsigned int>(data[0]); }
-			PacketType GetType() { return static_cast<PacketType>(GetTypeRaw()); }
-
-			uint32_t ReadInt() {
-				SPADES_MARK_FUNCTION();
-
-				uint32_t value = 0;
-				if (pos + 4 > data.size())
-					SPRaise("Received packet truncated");
-
-				value |= ((uint32_t)(uint8_t)data[pos++]);
-				value |= ((uint32_t)(uint8_t)data[pos++]) << 8;
-				value |= ((uint32_t)(uint8_t)data[pos++]) << 16;
-				value |= ((uint32_t)(uint8_t)data[pos++]) << 24;
-				return value;
-			}
-
-			uint16_t ReadShort() {
-				SPADES_MARK_FUNCTION();
-
-				uint32_t value = 0;
-				if (pos + 2 > data.size())
-					SPRaise("Received packet truncated");
-
-				value |= ((uint32_t)(uint8_t)data[pos++]);
-				value |= ((uint32_t)(uint8_t)data[pos++]) << 8;
-				return (uint16_t)value;
-			}
-
-			uint8_t ReadByte() {
-				SPADES_MARK_FUNCTION();
-
-				if (pos >= data.size())
-					SPRaise("Received packet truncated");
-
-				return (uint8_t)data[pos++];
-			}
-
-			float ReadFloat() {
-				SPADES_MARK_FUNCTION();
-				union {
-					float f;
-					uint32_t v;
-				};
-				v = ReadInt();
-				return f;
-			}
-
-			IntVector3 ReadIntColor() {
-				SPADES_MARK_FUNCTION();
-				IntVector3 col;
-				col.z = ReadByte(); // B
-				col.y = ReadByte(); // G
-				col.x = ReadByte(); // R
-				return col;
-			}
-			IntVector3 ReadIntVector3() {
-				SPADES_MARK_FUNCTION();
-				IntVector3 v;
-				v.x = ReadInt();
-				v.y = ReadInt();
-				v.z = ReadInt();
-				return v;
-			}
-			Vector3 ReadVector3() {
-				SPADES_MARK_FUNCTION();
-				Vector3 v;
-				v.x = ReadFloat();
-				v.y = ReadFloat();
-				v.z = ReadFloat();
-				return v;
-			}
-
-			std::size_t GetLength() { return data.size(); }
-			std::size_t GetPosition() { return pos; }
-			std::size_t GetNumRemainingBytes() { return data.size() - pos; }
-			std::vector<char> GetData() { return data; }
-
-			std::string ReadData(size_t siz) {
-				if (pos + siz > data.size())
-					SPRaise("Received packet truncated");
-
-				std::string s = std::string(data.data() + pos, siz);
-				pos += siz;
-				return s;
-			}
-			std::string ReadRemainingData() {
-				return std::string(data.data() + pos, data.size() - pos);
-			}
-
-			std::string ReadString(size_t siz) {
-				SPADES_MARK_FUNCTION_DEBUG();
-				// convert to C string once so that null-chars are removed
-				return DecodeString(ReadData(siz).c_str());
-			}
-			std::string ReadRemainingString() {
-				SPADES_MARK_FUNCTION_DEBUG();
-				// convert to C string once so that null-chars are removed
-				return DecodeString(ReadRemainingData().c_str());
-			}
-
-			void DumpDebug() {
-#if 1
-				char buf[512];
-				std::string str;
-
-				int bytes = (int)data.size();
-				snprintf(buf, sizeof(buf), "Packet 0x%02x [len=%d]", (int)GetType(), bytes);
-				str += buf;
-
-				if (bytes > 64)
-					bytes = 64;
-				for (int i = 0; i < bytes; i++) {
-					snprintf(buf, sizeof(buf), " %02x", (unsigned int)(unsigned char)data[i]);
-					str += buf;
-				}
-
-				SPLog("%s", str.c_str());
-#endif
-			}
-		};
 
 		class NetPacketWriter {
 			std::vector<char> data;
@@ -544,7 +354,10 @@ namespace spades {
 
 				stmp::optional<NetPacketReader> readerOrNone;
 				if (event.type == ENET_EVENT_TYPE_RECEIVE) {
-					readerOrNone.reset(event.packet);
+					std::vector<char> packetData(event.packet->data,
+					                             event.packet->data + event.packet->dataLength);
+					enet_packet_destroy(event.packet);
+					readerOrNone.reset(std::move(packetData));
 					auto& reader = readerOrNone.value();
 
 					// Record packet for demo if recording is active.
@@ -718,25 +531,6 @@ namespace spades {
 			if (!maybePlayer)
 				SPRaise("Failed to get local player: doesn't exist");
 			return maybePlayer.value();
-		}
-
-		PlayerInput ParsePlayerInput(uint8_t bits) {
-			PlayerInput inp;
-			inp.moveForward = (bits & (1 << 0)) != 0;
-			inp.moveBackward = (bits & (1 << 1)) != 0;
-			inp.moveLeft = (bits & (1 << 2)) != 0;
-			inp.moveRight = (bits & (1 << 3)) != 0;
-			inp.jump = (bits & (1 << 4)) != 0;
-			inp.crouch = (bits & (1 << 5)) != 0;
-			inp.sneak = (bits & (1 << 6)) != 0;
-			inp.sprint = (bits & (1 << 7)) != 0;
-			return inp;
-		}
-		WeaponInput ParseWeaponInput(uint8_t bits) {
-			WeaponInput inp;
-			inp.primary = ((bits & (1 << 0)) != 0);
-			inp.secondary = ((bits & (1 << 1)) != 0);
-			return inp;
 		}
 
 		std::string NetClient::DisconnectReasonString(uint32_t num) {

--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -41,6 +41,7 @@
 #include <Core/DeflateStream.h>
 #include <Core/Exception.h>
 #include <Core/Math.h>
+#include <Core/DynamicMemoryStream.h>
 #include <Core/MemoryStream.h>
 #include <Core/Settings.h>
 #include <Core/Strings.h>
@@ -370,6 +371,8 @@ namespace spades {
 			ENetPacket* CreatePacket(int flag = ENET_PACKET_FLAG_RELIABLE) {
 				return enet_packet_create(data.data(), data.size(), flag);
 			}
+
+			const std::vector<char>& GetData() const { return data; }
 		};
 
 		NetClient::NetClient(Client* c) : client(c), host(nullptr), peer(nullptr) {
@@ -402,14 +405,19 @@ namespace spades {
 			std::fill(savedPlayerTeam.begin(), savedPlayerTeam.end(), -1);
 
 			bandwidthMonitor.reset(new BandwidthMonitor(host));
+			demoRecorder.reset(new DemoRecorder());
 		}
 		NetClient::~NetClient() {
 			SPADES_MARK_FUNCTION();
+
+			if (demoRecorder && demoRecorder->IsRecording())
+				demoRecorder->StopRecording();
 
 			Disconnect();
 			if (host)
 				enet_host_destroy(host);
 			bandwidthMonitor.reset();
+			demoRecorder.reset();
 			SPLog("ENet host destroyed");
 		}
 
@@ -538,6 +546,12 @@ namespace spades {
 				if (event.type == ENET_EVENT_TYPE_RECEIVE) {
 					readerOrNone.reset(event.packet);
 					auto& reader = readerOrNone.value();
+
+					// Record packet for demo if recording is active
+					if (demoRecorder && demoRecorder->IsRecording()) {
+						auto data = reader.GetData();
+						demoRecorder->RecordPacket(data.data(), data.size());
+					}
 
 					try {
 						if (HandleHandshakePackets(reader))
@@ -1584,6 +1598,13 @@ namespace spades {
 			NetPacketWriter w(PacketTypeInputData);
 			w.WriteByte((uint8_t)GetLocalPlayer().GetId());
 			w.WriteByte(bits);
+
+			// Record to demo before sending (server doesn't echo this back)
+			if (demoRecorder && demoRecorder->IsRecording()) {
+				const auto& data = w.GetData();
+				demoRecorder->RecordPacket(data.data(), data.size());
+			}
+
 			enet_peer_send(peer, 0, w.CreatePacket());
 		}
 
@@ -1600,6 +1621,13 @@ namespace spades {
 			NetPacketWriter w(PacketTypeWeaponInput);
 			w.WriteByte((uint8_t)GetLocalPlayer().GetId());
 			w.WriteByte(bits);
+
+			// Record to demo before sending (server doesn't echo this back)
+			if (demoRecorder && demoRecorder->IsRecording()) {
+				const auto& data = w.GetData();
+				demoRecorder->RecordPacket(data.data(), data.size());
+			}
+
 			enet_peer_send(peer, 0, w.CreatePacket());
 		}
 
@@ -1627,6 +1655,13 @@ namespace spades {
 			w.WriteFloat(g.GetFuse());
 			w.WriteVector3(g.GetPosition());
 			w.WriteVector3(g.GetVelocity());
+
+			// Record to demo before sending (server doesn't echo this back)
+			if (demoRecorder && demoRecorder->IsRecording()) {
+				const auto& data = w.GetData();
+				demoRecorder->RecordPacket(data.data(), data.size());
+			}
+
 			enet_peer_send(peer, 0, w.CreatePacket());
 		}
 
@@ -1643,6 +1678,13 @@ namespace spades {
 				case Player::ToolGrenade: w.WriteByte((uint8_t)3); break;
 				default: SPInvalidEnum("tool", type);
 			}
+
+			// Record to demo before sending (server doesn't echo this back)
+			if (demoRecorder && demoRecorder->IsRecording()) {
+				const auto& data = w.GetData();
+				demoRecorder->RecordPacket(data.data(), data.size());
+			}
+
 			enet_peer_send(peer, 0, w.CreatePacket());
 		}
 
@@ -1652,6 +1694,13 @@ namespace spades {
 			NetPacketWriter w(PacketTypeSetColour);
 			w.WriteByte((uint8_t)GetLocalPlayer().GetId());
 			w.WriteColor(GetLocalPlayer().GetBlockColor());
+
+			// Record to demo before sending (server doesn't echo this back)
+			if (demoRecorder && demoRecorder->IsRecording()) {
+				const auto& data = w.GetData();
+				demoRecorder->RecordPacket(data.data(), data.size());
+			}
+
 			enet_peer_send(peer, 0, w.CreatePacket());
 		}
 
@@ -1699,6 +1748,13 @@ namespace spades {
 			w.WriteByte((uint8_t)GetLocalPlayer().GetId());
 			w.WriteByte((uint8_t)0); // clip_ammo; not used?
 			w.WriteByte((uint8_t)0); // reserve_ammo; not used?
+
+			// Record to demo before sending (server response is delayed)
+			if (demoRecorder && demoRecorder->IsRecording()) {
+				const auto& data = w.GetData();
+				demoRecorder->RecordPacket(data.data(), data.size());
+			}
+
 			enet_peer_send(peer, 0, w.CreatePacket());
 		}
 
@@ -1897,6 +1953,229 @@ namespace spades {
 			}
 
 			return text;
+		}
+
+		void NetClient::WriteInitialDemoState() {
+			SPADES_MARK_FUNCTION();
+
+			if (!demoRecorder || !demoRecorder->IsRecording())
+				return;
+
+			World* world = GetWorld() ? &GetWorld().value() : nullptr;
+			if (!world) {
+				SPLog("Cannot write initial demo state: no world");
+				return;
+			}
+
+			GameMap* map = world->GetMap().GetPointerOrNull();
+			if (!map) {
+				SPLog("Cannot write initial demo state: no map");
+				return;
+			}
+
+			SPLog("Writing initial demo state...");
+
+			// Step 1: Compress and write map data
+			{
+				// Save map to memory stream
+				DynamicMemoryStream rawMapStream;
+				map->Save(&rawMapStream);
+				rawMapStream.SetPosition(0);
+
+				// Compress the map data
+				DynamicMemoryStream compressedStream;
+				{
+					DeflateStream deflate(&compressedStream, CompressModeCompress, false);
+					const size_t bufSize = 65536;
+					std::vector<char> buf(bufSize);
+					size_t read;
+					while ((read = rawMapStream.Read(buf.data(), bufSize)) > 0) {
+						deflate.Write(buf.data(), read);
+					}
+					deflate.DeflateEnd();
+				}
+				compressedStream.SetPosition(0);
+				size_t compressedSize = compressedStream.GetLength();
+
+				// Write MapStart packet
+				{
+					NetPacketWriter w(PacketTypeMapStart);
+					w.WriteInt(static_cast<uint32_t>(compressedSize));
+					const auto& data = w.GetData();
+					demoRecorder->RecordPacket(data.data(), data.size());
+				}
+
+				// Write MapChunk packets (8KB chunks like the server does)
+				const size_t chunkSize = 8192;
+				std::vector<char> chunkBuf(chunkSize + 1);
+				chunkBuf[0] = static_cast<char>(PacketTypeMapChunk);
+				size_t read;
+				while ((read = compressedStream.Read(chunkBuf.data() + 1, chunkSize)) > 0) {
+					demoRecorder->RecordPacket(chunkBuf.data(), read + 1);
+				}
+			}
+
+			// Step 2: Write StateData packet
+			{
+				NetPacketWriter w(PacketTypeStateData);
+
+				// Local player ID
+				int localPlayerId = world->GetLocalPlayerIndex().value_or(0);
+				w.WriteByte(static_cast<uint8_t>(localPlayerId));
+
+				// Fog color (BGR format)
+				w.WriteColor(world->GetFogColor());
+
+				// Team colors and names
+				for (int t = 0; t < 2; t++) {
+					w.WriteColor(world->GetTeam(t).color);
+				}
+				for (int t = 0; t < 2; t++) {
+					w.WriteString(world->GetTeam(t).name, 10);
+				}
+
+				// Game mode
+				stmp::optional<IGameMode&> mode = world->GetMode();
+				if (mode && mode->ModeType() == IGameMode::m_CTF) {
+					auto& ctf = dynamic_cast<CTFGameMode&>(*mode);
+					w.WriteByte(0); // CTF mode
+
+					CTFGameMode::Team& team1 = ctf.GetTeam(0);
+					CTFGameMode::Team& team2 = ctf.GetTeam(1);
+
+					w.WriteByte(static_cast<uint8_t>(team1.score));
+					w.WriteByte(static_cast<uint8_t>(team2.score));
+					w.WriteByte(static_cast<uint8_t>(ctf.GetCaptureLimit()));
+
+					int intelFlags = (team1.hasIntel ? 1 : 0) | (team2.hasIntel ? 2 : 0);
+					w.WriteByte(static_cast<uint8_t>(intelFlags));
+
+					// Team 2's intel (blue team's flag)
+					if (team2.hasIntel) {
+						w.WriteByte(static_cast<uint8_t>(team2.carrierId));
+						// Padding
+						for (int i = 0; i < 11; i++) w.WriteByte(0);
+					} else {
+						w.WriteVector3(team1.flagPos);
+					}
+
+					// Team 1's intel (green team's flag)
+					if (team1.hasIntel) {
+						w.WriteByte(static_cast<uint8_t>(team1.carrierId));
+						// Padding
+						for (int i = 0; i < 11; i++) w.WriteByte(0);
+					} else {
+						w.WriteVector3(team2.flagPos);
+					}
+
+					// Base positions
+					w.WriteVector3(team1.basePos);
+					w.WriteVector3(team2.basePos);
+				} else if (mode && mode->ModeType() == IGameMode::m_TC) {
+					auto& tc = dynamic_cast<TCGameMode&>(*mode);
+					w.WriteByte(1); // TC mode
+
+					int numTerritories = tc.GetNumTerritories();
+					w.WriteByte(static_cast<uint8_t>(numTerritories));
+					for (int i = 0; i < numTerritories; i++) {
+						TCGameMode::Territory& t = tc.GetTerritory(i);
+						w.WriteVector3(t.pos);
+						w.WriteByte(static_cast<uint8_t>(t.ownerTeamId));
+					}
+				} else {
+					// Default to CTF with empty state
+					w.WriteByte(0);
+					for (int i = 0; i < 52; i++) w.WriteByte(0);
+				}
+
+				const auto& data = w.GetData();
+				demoRecorder->RecordPacket(data.data(), data.size());
+			}
+
+			// Step 3: Write ExistingPlayer packets for all players
+			for (unsigned int i = 0; i < world->GetNumPlayerSlots(); i++) {
+				stmp::optional<Player&> maybePlayer = world->GetPlayer(i);
+				if (!maybePlayer)
+					continue;
+
+				Player& p = *maybePlayer;
+
+				NetPacketWriter w(PacketTypeExistingPlayer);
+				w.WriteByte(static_cast<uint8_t>(i));  // Player ID
+				w.WriteByte(static_cast<uint8_t>(p.GetTeamId()));  // Team
+				w.WriteByte(static_cast<uint8_t>(p.GetWeaponType()));  // Weapon
+
+				// Tool
+				int tool = 0;
+				switch (p.GetTool()) {
+					case Player::ToolSpade: tool = 0; break;
+					case Player::ToolBlock: tool = 1; break;
+					case Player::ToolWeapon: tool = 2; break;
+					case Player::ToolGrenade: tool = 3; break;
+				}
+				w.WriteByte(static_cast<uint8_t>(tool));
+
+				// Kill count (score)
+				w.WriteInt(static_cast<uint32_t>(world->GetPlayerPersistent(i).score));
+
+				// Block color
+				w.WriteColor(p.GetBlockColor());
+
+				// Name
+				w.WriteString(world->GetPlayerPersistent(i).name);
+
+				const auto& data = w.GetData();
+				demoRecorder->RecordPacket(data.data(), data.size());
+			}
+
+			SPLog("Initial demo state written successfully");
+		}
+
+		bool NetClient::StartDemoRecording(const std::string& filename) {
+			SPADES_MARK_FUNCTION();
+
+			if (!demoRecorder) {
+				SPLog("Demo recorder not initialized");
+				return false;
+			}
+
+			if (status != NetClientStatusConnected) {
+				SPLog("Cannot start demo recording: not connected to a server");
+				return false;
+			}
+
+			std::string fname = filename.empty() ? DemoRecorder::GenerateFilename() : filename;
+			if (!demoRecorder->StartRecording(fname, protocolVersion))
+				return false;
+
+			// Write initial game state (map, players, etc.) to the demo
+			WriteInitialDemoState();
+
+			return true;
+		}
+
+		void NetClient::StopDemoRecording() {
+			SPADES_MARK_FUNCTION();
+
+			if (demoRecorder && demoRecorder->IsRecording())
+				demoRecorder->StopRecording();
+		}
+
+		bool NetClient::IsDemoRecording() const {
+			return demoRecorder && demoRecorder->IsRecording();
+		}
+
+		float NetClient::GetDemoRecordingTime() const {
+			return demoRecorder ? demoRecorder->GetRecordingTime() : 0.0f;
+		}
+
+		uint64_t NetClient::GetDemoPacketCount() const {
+			return demoRecorder ? demoRecorder->GetPacketCount() : 0;
+		}
+
+		const std::string& NetClient::GetDemoFilename() const {
+			static std::string empty;
+			return demoRecorder ? demoRecorder->GetFilename() : empty;
 		}
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/NetClient.h
+++ b/Sources/Client/NetClient.h
@@ -172,7 +172,7 @@ namespace spades {
 			 * Return a non-null reference to `GameProperties` for this connection.
 			 * Must be the connected state.
 			 */
-			std::shared_ptr<GameProperties>& GetGameProperties() override {
+			const std::shared_ptr<GameProperties>& GetGameProperties() override {
 				SPAssert(properties);
 				return properties;
 			}

--- a/Sources/Client/NetClient.h
+++ b/Sources/Client/NetClient.h
@@ -30,6 +30,7 @@
 
 #include "DemoRecorder.h"
 #include "GameConstants.h"
+#include "INetClient.h"
 #include "NetProtocol.h"
 #include "Player.h"
 #include <Core/Debug.h>
@@ -48,12 +49,6 @@ namespace spades {
 	namespace client {
 		class Client;
 		class Player;
-		enum NetClientStatus {
-			NetClientStatusNotConnected = 0,
-			NetClientStatusConnecting,
-			NetClientStatusReceivingMap,
-			NetClientStatusConnected
-		};
 
 		enum NetExtensionType {
 			ExtensionTypePlayerProperties = 0,
@@ -70,7 +65,7 @@ namespace spades {
 		struct GameProperties;
 		class GameMapLoader;
 
-		class NetClient {
+		class NetClient : public INetClient {
 			Client* client;
 			NetClientStatus status;
 			ENetHost* host;
@@ -160,11 +155,10 @@ namespace spades {
 
 		public:
 			NetClient(Client*);
-			~NetClient();
+			~NetClient() override;
 
-			NetClientStatus GetStatus() { return status; }
-
-			std::string GetStatusString();
+			NetClientStatus GetStatus() override { return status; }
+			std::string GetStatusString() override;
 
 			/**
 			 * Gets how much portion of the map has completed loading.
@@ -172,53 +166,57 @@ namespace spades {
 			 *
 			 * @return A value in range `[0, 1]`.
 			 */
-			float GetMapReceivingProgress();
+			float GetMapReceivingProgress() override;
 
 			/**
 			 * Return a non-null reference to `GameProperties` for this connection.
 			 * Must be the connected state.
 			 */
-			std::shared_ptr<GameProperties>& GetGameProperties() {
+			std::shared_ptr<GameProperties>& GetGameProperties() override {
 				SPAssert(properties);
 				return properties;
 			}
 
 			void Connect(const ServerAddress& hostname);
-			void Disconnect();
+			void Disconnect() override;
 
-			int GetPing();
-			float GetPacketLoss();
-			float GetPacketThrottle();
+			int GetPing() override;
+			float GetPacketLoss() override;
+			float GetPacketThrottle() override;
 
-			void DoEvents(int timeout = 0);
+			// INetClient::DoEvents — picks poll timeout based on connection status.
+			void DoEvents(float dt) override;
+			// Direct timeout control for internal/test use.
+			void DoEvents(int timeout);
 
-			void SendJoin(int team, WeaponType, std::string name, int score);
-			void SendPosition(Vector3);
-			void SendOrientation(Vector3);
-			void SendPlayerInput(PlayerInput);
-			void SendWeaponInput(WeaponInput);
-			void SendHit(int targetPlayerId, HitType type);
-			void SendGrenade(const Grenade&);
-			void SendTool();
-			void SendHeldBlockColor();
-			void SendBlockAction(IntVector3, BlockActionType);
-			void SendBlockLine(IntVector3 v1, IntVector3 v2);
-			void SendChat(std::string, bool global);
-			void SendReload();
-			void SendTeamChange(int team);
-			void SendWeaponChange(WeaponType);
+			void SendJoin(int team, WeaponType, std::string name, int score) override;
+			void SendPosition(Vector3) override;
+			void SendOrientation(Vector3) override;
+			void SendPlayerInput(PlayerInput) override;
+			void SendWeaponInput(WeaponInput) override;
+			void SendHit(int targetPlayerId, HitType type) override;
+			void SendGrenade(const Grenade&) override;
+			void SendTool() override;
+			void SendHeldBlockColor() override;
+			void SendBlockAction(IntVector3, BlockActionType) override;
+			void SendBlockLine(IntVector3 v1, IntVector3 v2) override;
+			void SendChat(std::string, bool global) override;
+			void SendReload() override;
+			void SendTeamChange(int team) override;
+			void SendWeaponChange(WeaponType) override;
 			void SendHandShakeValid(int challenge);
 
-			double GetDownlinkBps() { return bandwidthMonitor->GetDownlinkBps(); }
-			double GetUplinkBps() { return bandwidthMonitor->GetUplinkBps(); }
+			double GetDownlinkBps() override { return bandwidthMonitor->GetDownlinkBps(); }
+			double GetUplinkBps() override { return bandwidthMonitor->GetUplinkBps(); }
 
 			// Demo recording
-			bool StartDemoRecording(const std::string& filename = "", const std::string& context = "");
-			void StopDemoRecording();
-			bool IsDemoRecording() const;
-			float GetDemoRecordingTime() const;
-			uint64_t GetDemoPacketCount() const;
-			const std::string& GetDemoFilename() const;
+			bool StartDemoRecording(const std::string& filename = "",
+			                        const std::string& context = "") override;
+			void StopDemoRecording() override;
+			bool IsDemoRecording() const override;
+			float GetDemoRecordingTime() const override;
+			uint64_t GetDemoPacketCount() const override;
+			const std::string& GetDemoFilename() const override;
 		};
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/NetClient.h
+++ b/Sources/Client/NetClient.h
@@ -211,12 +211,12 @@ namespace spades {
 
 			// Demo recording
 			bool StartDemoRecording(const std::string& filename = "",
-			                        const std::string& context = "") override;
-			void StopDemoRecording() override;
-			bool IsDemoRecording() const override;
-			float GetDemoRecordingTime() const override;
-			uint64_t GetDemoPacketCount() const override;
-			const std::string& GetDemoFilename() const override;
+			                        const std::string& context = "");
+			void StopDemoRecording();
+			bool IsDemoRecording() const;
+			float GetDemoRecordingTime() const;
+			uint64_t GetDemoPacketCount() const;
+			const std::string& GetDemoFilename() const;
 		};
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/NetClient.h
+++ b/Sources/Client/NetClient.h
@@ -30,6 +30,7 @@
 
 #include "DemoRecorder.h"
 #include "GameConstants.h"
+#include "NetProtocol.h"
 #include "Player.h"
 #include <Core/Debug.h>
 #include <Core/Math.h>
@@ -62,7 +63,6 @@ namespace spades {
 		};
 
 		class World;
-		class NetPacketReader;
 		class NetPacketWriter;
 		struct PlayerInput;
 		struct WeaponInput;

--- a/Sources/Client/NetClient.h
+++ b/Sources/Client/NetClient.h
@@ -28,6 +28,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "DemoRecorder.h"
 #include "GameConstants.h"
 #include "Player.h"
 #include <Core/Debug.h>
@@ -121,6 +122,8 @@ namespace spades {
 
 			std::unique_ptr<BandwidthMonitor> bandwidthMonitor;
 
+			std::unique_ptr<DemoRecorder> demoRecorder;
+
 			std::vector<Vector3> savedPlayerPos;
 			std::vector<Vector3> savedPlayerFront;
 			std::vector<int> savedPlayerTeam;
@@ -146,6 +149,9 @@ namespace spades {
 			std::string DisconnectReasonString(uint32_t);
 
 			void MapLoaded();
+
+			/** Writes the initial game state to the demo recorder (map, players, etc.) */
+			void WriteInitialDemoState();
 
 			void SendMapCached();
 			void SendVersion();
@@ -205,6 +211,14 @@ namespace spades {
 
 			double GetDownlinkBps() { return bandwidthMonitor->GetDownlinkBps(); }
 			double GetUplinkBps() { return bandwidthMonitor->GetUplinkBps(); }
+
+			// Demo recording
+			bool StartDemoRecording(const std::string& filename = "");
+			void StopDemoRecording();
+			bool IsDemoRecording() const;
+			float GetDemoRecordingTime() const;
+			uint64_t GetDemoPacketCount() const;
+			const std::string& GetDemoFilename() const;
 		};
 	} // namespace client
 } // namespace spades

--- a/Sources/Client/NetClient.h
+++ b/Sources/Client/NetClient.h
@@ -213,7 +213,7 @@ namespace spades {
 			double GetUplinkBps() { return bandwidthMonitor->GetUplinkBps(); }
 
 			// Demo recording
-			bool StartDemoRecording(const std::string& filename = "");
+			bool StartDemoRecording(const std::string& filename = "", const std::string& context = "");
 			void StopDemoRecording();
 			bool IsDemoRecording() const;
 			float GetDemoRecordingTime() const;

--- a/Sources/Client/NetProtocol.h
+++ b/Sources/Client/NetProtocol.h
@@ -1,0 +1,228 @@
+/*
+ Copyright (c) 2013 yvt
+ based on code of pysnip (c) Mathias Kaerlev 2011-2012.
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "Player.h"
+#include <Core/CP437.h>
+#include <Core/Debug.h>
+#include <Core/Exception.h>
+#include <Core/Math.h>
+
+namespace spades {
+	namespace client {
+
+		// Object IDs used in PacketTypeMoveObject
+		enum { BLUE_FLAG = 0, GREEN_FLAG = 1, BLUE_BASE = 2, GREEN_BASE = 3 };
+
+		enum PacketType {
+			PacketTypePositionData = 0,    // C2S2P
+			PacketTypeOrientationData = 1, // C2S2P
+			PacketTypeWorldUpdate = 2,     // S2C
+			PacketTypeInputData = 3,       // C2S2P
+			PacketTypeWeaponInput = 4,     // C2S2P
+			PacketTypeHitPacket = 5,       // C2S
+			PacketTypeSetHP = 5,           // S2C
+			PacketTypeGrenadePacket = 6,   // C2S2P
+			PacketTypeSetTool = 7,         // C2S2P
+			PacketTypeSetColour = 8,       // C2S2P
+			PacketTypeExistingPlayer = 9,  // C2S2P
+			PacketTypeShortPlayerData = 10, // S2C
+			PacketTypeMoveObject = 11,     // S2C
+			PacketTypeCreatePlayer = 12,   // S2C
+			PacketTypeBlockAction = 13,    // C2S2P
+			PacketTypeBlockLine = 14,      // C2S2P
+			PacketTypeStateData = 15,      // S2C
+			PacketTypeKillAction = 16,     // S2C
+			PacketTypeChatMessage = 17,    // C2S2P
+			PacketTypeMapStart = 18,       // S2C
+			PacketTypeMapChunk = 19,       // S2C
+			PacketTypePlayerLeft = 20,     // S2P
+			PacketTypeTerritoryCapture = 21, // S2P
+			PacketTypeProgressBar = 22,    // S2P
+			PacketTypeIntelCapture = 23,   // S2P
+			PacketTypeIntelPickup = 24,    // S2P
+			PacketTypeIntelDrop = 25,      // S2P
+			PacketTypeRestock = 26,        // S2P
+			PacketTypeFogColour = 27,      // S2C
+			PacketTypeWeaponReload = 28,   // C2S2P
+			PacketTypeChangeTeam = 29,     // C2S2P
+			PacketTypeChangeWeapon = 30,   // C2S2P
+			PacketTypeMapCached = 31,      // S2C
+			PacketTypeHandShakeInit = 31,  // S2C
+			PacketTypeHandShakeReturn = 32, // C2S
+			PacketTypeVersionGet = 33,     // S2C
+			PacketTypeVersionSend = 34,    // C2S
+			PacketTypeExtensionInfo = 60,
+			PacketTypePlayerProperties = 64,
+		};
+
+		inline PlayerInput ParsePlayerInput(uint8_t bits) {
+			PlayerInput inp;
+			inp.moveForward  = (bits & (1 << 0)) != 0;
+			inp.moveBackward = (bits & (1 << 1)) != 0;
+			inp.moveLeft     = (bits & (1 << 2)) != 0;
+			inp.moveRight    = (bits & (1 << 3)) != 0;
+			inp.jump         = (bits & (1 << 4)) != 0;
+			inp.crouch       = (bits & (1 << 5)) != 0;
+			inp.sneak        = (bits & (1 << 6)) != 0;
+			inp.sprint       = (bits & (1 << 7)) != 0;
+			return inp;
+		}
+
+		inline WeaponInput ParseWeaponInput(uint8_t bits) {
+			WeaponInput inp;
+			inp.primary   = (bits & (1 << 0)) != 0;
+			inp.secondary = (bits & (1 << 1)) != 0;
+			return inp;
+		}
+
+		/**
+		 * Reads fields from a raw packet byte buffer. The first byte (packet type) is
+		 * consumed on construction; all Read* methods advance the internal cursor.
+		 */
+		class NetPacketReader {
+			std::vector<char> data;
+			size_t pos;
+
+			static constexpr char UTFSign = -1;
+
+			static std::string DecodeString(std::string s) {
+				if (!s.empty() && s[0] == UTFSign)
+					return s.substr(1);
+				return CP437::Decode(s);
+			}
+
+		public:
+			explicit NetPacketReader(std::vector<char> inData)
+			    : data(std::move(inData)), pos(1) {}
+
+			unsigned int GetTypeRaw() {
+				return static_cast<unsigned int>(static_cast<uint8_t>(data[0]));
+			}
+			PacketType GetType() { return static_cast<PacketType>(GetTypeRaw()); }
+
+			uint32_t ReadInt() {
+				if (pos + 4 > data.size())
+					SPRaise("Received packet truncated");
+				uint32_t value = 0;
+				value |= ((uint32_t)(uint8_t)data[pos++]);
+				value |= ((uint32_t)(uint8_t)data[pos++]) << 8;
+				value |= ((uint32_t)(uint8_t)data[pos++]) << 16;
+				value |= ((uint32_t)(uint8_t)data[pos++]) << 24;
+				return value;
+			}
+
+			uint16_t ReadShort() {
+				if (pos + 2 > data.size())
+					SPRaise("Received packet truncated");
+				uint32_t value = 0;
+				value |= ((uint32_t)(uint8_t)data[pos++]);
+				value |= ((uint32_t)(uint8_t)data[pos++]) << 8;
+				return (uint16_t)value;
+			}
+
+			uint8_t ReadByte() {
+				if (pos >= data.size())
+					SPRaise("Received packet truncated");
+				return (uint8_t)data[pos++];
+			}
+
+			float ReadFloat() {
+				union {
+					float f;
+					uint32_t v;
+				};
+				v = ReadInt();
+				return f;
+			}
+
+			IntVector3 ReadIntColor() {
+				IntVector3 col;
+				col.z = ReadByte(); // B
+				col.y = ReadByte(); // G
+				col.x = ReadByte(); // R
+				return col;
+			}
+
+			IntVector3 ReadIntVector3() {
+				IntVector3 v;
+				v.x = ReadInt();
+				v.y = ReadInt();
+				v.z = ReadInt();
+				return v;
+			}
+
+			Vector3 ReadVector3() {
+				Vector3 v;
+				v.x = ReadFloat();
+				v.y = ReadFloat();
+				v.z = ReadFloat();
+				return v;
+			}
+
+			std::size_t GetLength() { return data.size(); }
+			std::size_t GetPosition() { return pos; }
+			std::size_t GetNumRemainingBytes() { return data.size() - pos; }
+			std::vector<char> GetData() { return data; }
+
+			std::string ReadData(size_t siz) {
+				if (pos + siz > data.size())
+					SPRaise("Received packet truncated");
+				std::string s(data.data() + pos, siz);
+				pos += siz;
+				return s;
+			}
+
+			std::string ReadRemainingData() {
+				return std::string(data.data() + pos, data.size() - pos);
+			}
+
+			std::string ReadString(size_t siz) {
+				return DecodeString(ReadData(siz).c_str());
+			}
+
+			std::string ReadRemainingString() {
+				return DecodeString(ReadRemainingData().c_str());
+			}
+
+			void DumpDebug() {
+				char buf[512];
+				std::string str;
+				int bytes = (int)data.size();
+				snprintf(buf, sizeof(buf), "Packet 0x%02x [len=%d]", (int)GetType(), bytes);
+				str += buf;
+				if (bytes > 64)
+					bytes = 64;
+				for (int i = 0; i < bytes; i++) {
+					snprintf(buf, sizeof(buf), " %02x", (unsigned int)(unsigned char)data[i]);
+					str += buf;
+				}
+				SPLog("%s", str.c_str());
+			}
+		};
+
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/NetProtocol.h
+++ b/Sources/Client/NetProtocol.h
@@ -119,10 +119,10 @@ namespace spades {
 			explicit NetPacketReader(std::vector<char> inData)
 			    : data(std::move(inData)), pos(1) {}
 
-			unsigned int GetTypeRaw() {
+			unsigned int GetTypeRaw() const {
 				return static_cast<unsigned int>(static_cast<uint8_t>(data[0]));
 			}
-			PacketType GetType() { return static_cast<PacketType>(GetTypeRaw()); }
+			PacketType GetType() const { return static_cast<PacketType>(GetTypeRaw()); }
 
 			uint32_t ReadInt() {
 				if (pos + 4 > data.size())
@@ -183,10 +183,10 @@ namespace spades {
 				return v;
 			}
 
-			std::size_t GetLength() { return data.size(); }
-			std::size_t GetPosition() { return pos; }
-			std::size_t GetNumRemainingBytes() { return data.size() - pos; }
-			std::vector<char> GetData() { return data; }
+			std::size_t GetLength() const { return data.size(); }
+			std::size_t GetPosition() const { return pos; }
+			std::size_t GetNumRemainingBytes() const { return data.size() - pos; }
+			const std::vector<char>& GetData() const { return data; }
 
 			std::string ReadData(size_t siz) {
 				if (pos + siz > data.size())
@@ -208,7 +208,7 @@ namespace spades {
 				return DecodeString(ReadRemainingData().c_str());
 			}
 
-			void DumpDebug() {
+			void DumpDebug() const {
 				char buf[512];
 				std::string str;
 				int bytes = (int)data.size();

--- a/Sources/Client/NetProtocol.h
+++ b/Sources/Client/NetProtocol.h
@@ -43,7 +43,7 @@ namespace spades {
 			PacketTypeWorldUpdate = 2,     // S2C
 			PacketTypeInputData = 3,       // C2S2P
 			PacketTypeWeaponInput = 4,     // C2S2P
-			PacketTypeHitPacket = 5,       // C2S
+			PacketTypeHitPacket = 5,       // C2S  (same wire value as SetHP — direction distinguishes them)
 			PacketTypeSetHP = 5,           // S2C
 			PacketTypeGrenadePacket = 6,   // C2S2P
 			PacketTypeSetTool = 7,         // C2S2P
@@ -70,7 +70,7 @@ namespace spades {
 			PacketTypeWeaponReload = 28,   // C2S2P
 			PacketTypeChangeTeam = 29,     // C2S2P
 			PacketTypeChangeWeapon = 30,   // C2S2P
-			PacketTypeMapCached = 31,      // S2C
+			PacketTypeMapCached = 31,      // S2C  (same wire value as HandShakeInit — used in different protocol versions)
 			PacketTypeHandShakeInit = 31,  // S2C
 			PacketTypeHandShakeReturn = 32, // C2S
 			PacketTypeVersionGet = 33,     // S2C

--- a/Sources/Client/NetProtocol.h
+++ b/Sources/Client/NetProtocol.h
@@ -1,21 +1,22 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2026 Francois ND
+ based on code of OpenSpades (c) yvt 2013.
  based on code of pysnip (c) Mathias Kaerlev 2011-2012.
 
- This file is part of OpenSpades.
+ This file is part of ZeroSpades, a fork of OpenSpades.
 
- OpenSpades is free software: you can redistribute it and/or modify
+ ZeroSpades is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- OpenSpades is distributed in the hope that it will be useful,
+ ZeroSpades is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
 

--- a/Sources/Client/Player.cpp
+++ b/Sources/Client/Player.cpp
@@ -229,6 +229,8 @@ namespace spades {
 				weapon->SetShooting(newInput.primary);
 			} else if (tool == ToolWeapon) {
 				// non-local weapon player: no local simulation needed
+			} else if (tool == ToolGrenade) {
+				// non-local grenade player: no local simulation needed
 			} else {
 				SPAssert(false);
 			}

--- a/Sources/Core/CP437.h
+++ b/Sources/Core/CP437.h
@@ -3,6 +3,8 @@
  * WTFPL
  */
 
+#pragma once
+
 #include <cstdint>
 #include <string>
 

--- a/Sources/Core/DeflateStream.cpp
+++ b/Sources/Core/DeflateStream.cpp
@@ -113,6 +113,11 @@ namespace spades {
 			SPRaise("State is invalid");
 		}
 
+		// Flush any remaining buffered data before finishing
+		if (!buffer.empty()) {
+			CompressBuffer();
+		}
+
 		char outputBuffer[chunkSize];
 
 		zstream.avail_in = 0;

--- a/Sources/Core/ServerAddress.cpp
+++ b/Sources/Core/ServerAddress.cpp
@@ -94,4 +94,12 @@ namespace spades {
 		return mAddress;
 	}
 
+	std::string ServerAddress::GetIPString() const {
+		ENetAddress addr = GetENetAddress();
+		char buf[64];
+		if (enet_address_get_host_ip(&addr, buf, sizeof(buf)) == 0)
+			return buf;
+		return StripProtocol(mAddress);
+	}
+
 }; // namespace spades

--- a/Sources/Core/ServerAddress.h
+++ b/Sources/Core/ServerAddress.h
@@ -42,6 +42,9 @@ namespace spades {
 		ProtocolVersion GetProtocolVersion() const { return mVersion; }
 		std::string ToString(bool includeProtocol = true) const;
 
+		/** Returns the resolved host as a dotted-decimal IPv4 string, e.g. "1.2.3.4". */
+		std::string GetIPString() const;
+
 		static uint32_t ParseIntegerAddress(const std::string& str);
 	};
 } // namespace spades

--- a/Sources/Core/Stopwatch.cpp
+++ b/Sources/Core/Stopwatch.cpp
@@ -45,5 +45,5 @@ static double GetSWTicks() {
 namespace spades {
 	Stopwatch::Stopwatch() { Reset(); }
 	void Stopwatch::Reset() { start = GetSWTicks(); }
-	double Stopwatch::GetTime() { return GetSWTicks() - start; }
+	double Stopwatch::GetTime() const { return GetSWTicks() - start; }
 } // namespace spades

--- a/Sources/Core/Stopwatch.h
+++ b/Sources/Core/Stopwatch.h
@@ -29,6 +29,6 @@ namespace spades {
 		void Reset();
 
 		/** @return elapsed time in seconds */
-		double GetTime();
+		double GetTime() const;
 	};
 }

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -491,6 +491,9 @@ int main(int argc, char** argv) {
 
 #endif
 
+		// Set the demos base directory now that g_userResourceDirectory is final.
+		spades::client::DemoRecorder::SetBaseDirectory(spades::g_userResourceDirectory);
+
 		// start log output to SystemMessages.log
 		try {
 			spades::StartLog();

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -175,8 +175,6 @@ namespace {
 #endif
 
 namespace spades {
-	std::string g_recordDemoPath;
-	bool g_autoRecordDemo = false;
 	std::string g_pendingMapName;
 	std::string g_pendingServerName;
 }
@@ -191,42 +189,18 @@ namespace {
 
 	bool g_printVersion = false;
 	bool g_printHelp = false;
-	bool g_printRecordList = false;
 
 	void printHelp(char* binaryName) {
-		printf("usage: %s [server_address] [v=protocol_version] [--replay demo.dem] [--record [FILE]] [-h|--help] [-v|--version]\n",
+		printf("usage: %s [server_address] [v=protocol_version] [--replay demo.dem] [-h|--help] [-v|--version]\n",
 		       binaryName);
 		printf("  server_address       aos:// server address to connect to\n");
 		printf("  v=0.75 or v=0.76     protocol version (default: 0.75)\n");
 		printf("  --replay FILE        play back a demo recording\n");
 		printf("  -r FILE              play back a demo recording (short form)\n");
-		printf("  --record [FILE]      record demos; FILE is used as base name (FILE_1.dem etc.)\n");
-		printf("                       omit FILE to auto-name recordings as Demos/YYYY-MM-DD-HH-MM-gamemode.dem\n");
-		printf("  --record-list        list recordings in the Demos/ folder\n");
 		printf("  -h, --help           show this help message\n");
 		printf("  -v, --version        show version information\n");
-		printf("\nAuto-recording can also be enabled permanently with the cg_autoRecord setting.\n");
+		printf("\nAuto-recording can be enabled with the cg_autoRecord setting.\n");
 		printf("Recordings are kept in the Demos/ folder; only the last 10 are retained.\n");
-	}
-
-	void printRecordList() {
-		auto files = spades::client::DemoRecorder::ListRecordings();
-		if (files.empty()) {
-			printf("No recordings found in Demos/\n");
-			return;
-		}
-		printf("%zu recording(s) in Demos/:\n", files.size());
-		for (const auto& path : files) {
-			FILE* f = fopen(path.c_str(), "rb");
-			if (f) {
-				fseek(f, 0, SEEK_END);
-				long kb = ftell(f) / 1024;
-				fclose(f);
-				printf("  %s  (%ld KB)\n", path.c_str(), kb);
-			} else {
-				printf("  %s\n", path.c_str());
-			}
-		}
 	}
 
 	std::regex const hostNameRegex{"aos://.*"};
@@ -263,26 +237,6 @@ namespace {
 					return ++i;
 				}
 				return 0;
-			}
-			if (!strcasecmp(a, "--record-list") || !strcasecmp(a, "--record-ls")) {
-				g_printRecordList = true;
-				return ++i;
-			}
-			if (!strcasecmp(a, "--record")) {
-				++i;
-				if (i < argc && argv[i][0] != '-') {
-					spades::g_recordDemoPath = argv[i++];
-				} else {
-					spades::g_autoRecordDemo = true;
-				}
-				return i;
-			}
-			// Handle bare .dem file path
-			size_t len = strlen(a);
-			if (len > 4 && !strcasecmp(a + len - 4, ".dem")) {
-				g_replayDemo = true;
-				g_replayDemoPath = a;
-				return ++i;
 			}
 		}
 
@@ -395,11 +349,6 @@ int main(int argc, char** argv) {
 
 	if (g_printHelp) {
 		printHelp(argv[0]);
-		return 0;
-	}
-
-	if (g_printRecordList) {
-		printRecordList();
 		return 0;
 	}
 

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -173,17 +173,30 @@ namespace {
 } // namespace
 #endif
 
+namespace spades {
+	std::string g_recordDemoPath;
+}
+
 namespace {
 	bool g_autoconnect = false;
 	std::string g_autoconnectHostName;
 	spades::ProtocolVersion g_autoconnectProtocolVersion = spades::ProtocolVersion::v075;
 
+	bool g_replayDemo = false;
+	std::string g_replayDemoPath;
+
 	bool g_printVersion = false;
 	bool g_printHelp = false;
 
 	void printHelp(char* binaryName) {
-		printf("usage: %s [server_address] [v=protocol_version] [-h|--help] [-v|--version] \n",
-			   binaryName);
+		printf("usage: %s [server_address] [v=protocol_version] [--replay demo.dem] [--record FILE] [-h|--help] [-v|--version]\n",
+		       binaryName);
+		printf("  server_address    aos:// server address to connect to\n");
+		printf("  v=0.75 or v=0.76  protocol version (default: 0.75)\n");
+		printf("  --replay FILE     play back a demo recording\n");
+		printf("  --record FILE     record demos to FILE_1.dem, FILE_2.dem, etc.\n");
+		printf("  -h, --help        show this help message\n");
+		printf("  -v, --version     show version information\n");
 	}
 
 	std::regex const hostNameRegex{"aos://.*"};
@@ -213,6 +226,28 @@ namespace {
 				g_printHelp = true;
 				return ++i;
 			}
+			if (!strcasecmp(a, "--replay") || !strcasecmp(a, "-r")) {
+				if (i + 1 < argc) {
+					g_replayDemo = true;
+					g_replayDemoPath = argv[++i];
+					return ++i;
+				}
+				return 0;
+			}
+			if (!strcasecmp(a, "--record")) {
+				if (i + 1 < argc) {
+					spades::g_recordDemoPath = argv[++i];
+					return ++i;
+				}
+				return 0;
+			}
+			// Handle bare .dem file path
+			size_t len = strlen(a);
+			if (len > 4 && !strcasecmp(a + len - 4, ".dem")) {
+				g_replayDemo = true;
+				g_replayDemoPath = a;
+				return ++i;
+			}
 		}
 
 		return 0;
@@ -239,6 +274,27 @@ namespace spades {
 			ConcreteRunner(const spades::ServerAddress& addr) : addr(addr) {}
 		};
 		ConcreteRunner runner(addr);
+		runner.RunProtected();
+	}
+
+	void StartDemoReplay(const std::string& demoPath) {
+		class DemoRunner : public spades::gui::Runner {
+			std::string demoPath;
+
+		protected:
+			spades::gui::View* CreateView(spades::client::IRenderer* renderer,
+			                              spades::client::IAudioDevice* audio) override {
+				auto fontManager = Handle<client::FontManager>::New(renderer);
+				auto innerView = Handle<client::Client>::New(
+				    renderer, audio, ServerAddress(), fontManager, demoPath);
+				return new spades::gui::ConsoleScreen(renderer, audio, fontManager,
+				                                      std::move(innerView).Cast<gui::View>());
+			}
+
+		public:
+			DemoRunner(const std::string& path) : demoPath(path) {}
+		};
+		DemoRunner runner(demoPath);
 		runner.RunProtected();
 	}
 	void StartMainScreen() {
@@ -587,7 +643,12 @@ int main(int argc, char** argv) {
 		pumpEvents();
 
 		// everything is now ready!
-		if (!g_autoconnect) {
+		if (g_replayDemo) {
+			splashWindow.reset();
+
+			SPLog("Starting demo replay: %s", g_replayDemoPath.c_str());
+			spades::StartDemoReplay(g_replayDemoPath);
+		} else if (!g_autoconnect) {
 			if (!((int)cl_showStartupWindow != 0 || splashWindow->IsStartupScreenRequested())) {
 				splashWindow.reset();
 

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -177,6 +177,8 @@ namespace {
 namespace spades {
 	std::string g_recordDemoPath;
 	bool g_autoRecordDemo = false;
+	std::string g_pendingMapName;
+	std::string g_pendingServerName;
 }
 
 namespace {
@@ -199,7 +201,7 @@ namespace {
 		printf("  --replay FILE        play back a demo recording\n");
 		printf("  -r FILE              play back a demo recording (short form)\n");
 		printf("  --record [FILE]      record demos; FILE is used as base name (FILE_1.dem etc.)\n");
-		printf("                       omit FILE to auto-name recordings as Demos/YYYYMMDD_HHMMSS_host.dem\n");
+		printf("                       omit FILE to auto-name recordings as Demos/YYYY-MM-DD-HH-MM-gamemode.dem\n");
 		printf("  --record-list        list recordings in the Demos/ folder\n");
 		printf("  -h, --help           show this help message\n");
 		printf("  -v, --version        show version information\n");

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -35,6 +35,7 @@
 #include "Runner.h"
 #include "SplashWindow.h"
 #include <Client/Client.h>
+#include <Client/DemoRecorder.h>
 #include <Client/Fonts.h>
 #include <Client/GameMap.h>
 #include <Core/ConcurrentDispatch.h>
@@ -175,6 +176,7 @@ namespace {
 
 namespace spades {
 	std::string g_recordDemoPath;
+	bool g_autoRecordDemo = false;
 }
 
 namespace {
@@ -187,16 +189,42 @@ namespace {
 
 	bool g_printVersion = false;
 	bool g_printHelp = false;
+	bool g_printRecordList = false;
 
 	void printHelp(char* binaryName) {
-		printf("usage: %s [server_address] [v=protocol_version] [--replay demo.dem] [--record FILE] [-h|--help] [-v|--version]\n",
+		printf("usage: %s [server_address] [v=protocol_version] [--replay demo.dem] [--record [FILE]] [-h|--help] [-v|--version]\n",
 		       binaryName);
-		printf("  server_address    aos:// server address to connect to\n");
-		printf("  v=0.75 or v=0.76  protocol version (default: 0.75)\n");
-		printf("  --replay FILE     play back a demo recording\n");
-		printf("  --record FILE     record demos to FILE_1.dem, FILE_2.dem, etc.\n");
-		printf("  -h, --help        show this help message\n");
-		printf("  -v, --version     show version information\n");
+		printf("  server_address       aos:// server address to connect to\n");
+		printf("  v=0.75 or v=0.76     protocol version (default: 0.75)\n");
+		printf("  --replay FILE        play back a demo recording\n");
+		printf("  -r FILE              play back a demo recording (short form)\n");
+		printf("  --record [FILE]      record demos; FILE is used as base name (FILE_1.dem etc.)\n");
+		printf("                       omit FILE to auto-name recordings as Demos/YYYYMMDD_HHMMSS_host.dem\n");
+		printf("  --record-list        list recordings in the Demos/ folder\n");
+		printf("  -h, --help           show this help message\n");
+		printf("  -v, --version        show version information\n");
+		printf("\nAuto-recording can also be enabled permanently with the cg_autoRecord setting.\n");
+		printf("Recordings are kept in the Demos/ folder; only the last 10 are retained.\n");
+	}
+
+	void printRecordList() {
+		auto files = spades::client::DemoRecorder::ListRecordings();
+		if (files.empty()) {
+			printf("No recordings found in Demos/\n");
+			return;
+		}
+		printf("%zu recording(s) in Demos/:\n", files.size());
+		for (const auto& path : files) {
+			FILE* f = fopen(path.c_str(), "rb");
+			if (f) {
+				fseek(f, 0, SEEK_END);
+				long kb = ftell(f) / 1024;
+				fclose(f);
+				printf("  %s  (%ld KB)\n", path.c_str(), kb);
+			} else {
+				printf("  %s\n", path.c_str());
+			}
+		}
 	}
 
 	std::regex const hostNameRegex{"aos://.*"};
@@ -234,12 +262,18 @@ namespace {
 				}
 				return 0;
 			}
+			if (!strcasecmp(a, "--record-list") || !strcasecmp(a, "--record-ls")) {
+				g_printRecordList = true;
+				return ++i;
+			}
 			if (!strcasecmp(a, "--record")) {
-				if (i + 1 < argc) {
-					spades::g_recordDemoPath = argv[++i];
-					return ++i;
+				++i;
+				if (i < argc && argv[i][0] != '-') {
+					spades::g_recordDemoPath = argv[i++];
+				} else {
+					spades::g_autoRecordDemo = true;
 				}
-				return 0;
+				return i;
 			}
 			// Handle bare .dem file path
 			size_t len = strlen(a);
@@ -359,6 +393,11 @@ int main(int argc, char** argv) {
 
 	if (g_printHelp) {
 		printHelp(argv[0]);
+		return 0;
+	}
+
+	if (g_printRecordList) {
+		printRecordList();
 		return 0;
 	}
 

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -199,7 +199,7 @@ namespace {
 		printf("  -r FILE              play back a demo recording (short form)\n");
 		printf("  -h, --help           show this help message\n");
 		printf("  -v, --version        show version information\n");
-		printf("\nAuto-recording can be enabled with the cg_autoRecord setting.\n");
+		printf("\nAuto-recording can be enabled with the cg_demoAutoRecord setting.\n");
 		printf("Recordings are kept in the Demos/ folder; only the last 10 are retained.\n");
 	}
 

--- a/Sources/Gui/Main.h
+++ b/Sources/Gui/Main.h
@@ -30,4 +30,5 @@ namespace spades {
 
 	void StartClient(const ServerAddress&);
 	void StartMainScreen();
+	void StartDemoReplay(const std::string& demoPath);
 } // namespace spades

--- a/Sources/Gui/MainScreen.cpp
+++ b/Sources/Gui/MainScreen.cpp
@@ -370,5 +370,17 @@ namespace spades {
 			}
 			return "";
 		}
+
+		std::string MainScreen::PlayDemo(const std::string& demoPath) {
+			try {
+				subview = Handle<client::Client>::New(&*renderer, &*audioDevice,
+				              ServerAddress(), fontManager, demoPath)
+				            .Cast<View>();
+			} catch (const std::exception& ex) {
+				SPLog("[!] Error starting demo playback: %s", ex.what());
+				return ex.what();
+			}
+			return "";
+		}
 	} // namespace gui
 } // namespace spades

--- a/Sources/Gui/MainScreen.h
+++ b/Sources/Gui/MainScreen.h
@@ -50,6 +50,7 @@ namespace spades {
 			void RestoreRenderer();
 
 			std::string Connect(const ServerAddress &host);
+		std::string PlayDemo(const std::string &demoPath);
 
 		protected:
 			~MainScreen();

--- a/Sources/Gui/MainScreenHelper.cpp
+++ b/Sources/Gui/MainScreenHelper.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdio>
 #include <cstdint>
 #include <memory>
 #include <sys/stat.h>
@@ -459,6 +460,10 @@ namespace spades {
 			if (mainScreen == NULL)
 				return "mainScreen == NULL";
 			return mainScreen->PlayDemo(filename);
+		}
+
+		bool MainScreenHelper::DeleteDemo(std::string filename) {
+			return std::remove(filename.c_str()) == 0;
 		}
 
 		std::string MainScreenHelper::GetPendingErrorMessage() {

--- a/Sources/Gui/MainScreenHelper.cpp
+++ b/Sources/Gui/MainScreenHelper.cpp
@@ -22,7 +22,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <memory>
+#include <sys/stat.h>
 
 #include <curl/curl.h>
 #include <json/json.h>
@@ -444,6 +446,13 @@ namespace spades {
 			for (size_t i = 0; i < recordings.size(); i++)
 				arr->SetValue((asUINT)i, &recordings[i]);
 			return arr;
+		}
+
+		int64_t MainScreenHelper::GetDemoFileSize(std::string filename) {
+			struct stat st;
+			if (stat(filename.c_str(), &st) == 0)
+				return static_cast<int64_t>(st.st_size);
+			return -1;
 		}
 
 		std::string MainScreenHelper::PlayDemo(std::string filename) {

--- a/Sources/Gui/MainScreenHelper.cpp
+++ b/Sources/Gui/MainScreenHelper.cpp
@@ -39,6 +39,9 @@
 DEFINE_SPADES_SETTING(cl_serverListUrl, "http://services.buildandshoot.com/serverlist.json");
 
 namespace spades {
+	extern std::string g_pendingMapName;
+	extern std::string g_pendingServerName;
+
 	namespace {
 		struct CURLEasyDeleter {
 			void operator()(CURL *ptr) const { curl_easy_cleanup(ptr); }
@@ -406,9 +409,20 @@ namespace spades {
 			return result.get().ping.value_or(-1);
 		}
 
-		std::string MainScreenHelper::ConnectServer(std::string hostname, int protocolVersion) {
+		std::string MainScreenHelper::ConnectServer(std::string hostname, int protocolVersion,
+		                                             std::string mapName) {
 			if (mainScreen == NULL) {
 				return "mainScreen == NULL";
+			}
+			g_pendingMapName = mapName;
+			g_pendingServerName = "";
+			if (result) {
+				for (const auto& item : result->list) {
+					if (item->GetAddress() == hostname) {
+						g_pendingServerName = item->GetName();
+						break;
+					}
+				}
 			}
 			return mainScreen->Connect(ServerAddress(
 			  hostname, protocolVersion == 3 ? ProtocolVersion::v075 : ProtocolVersion::v076));

--- a/Sources/Gui/MainScreenHelper.cpp
+++ b/Sources/Gui/MainScreenHelper.cpp
@@ -418,11 +418,11 @@ namespace spades {
 				return "mainScreen == NULL";
 			}
 			g_pendingMapName = mapName;
-			g_pendingServerName = "";
+			g_pendingServerName = hostname; // fallback: use address as server name
 			if (result) {
 				for (const auto& item : result->list) {
 					if (item->GetAddress() == hostname) {
-						g_pendingServerName = item->GetName();
+						g_pendingServerName = item->GetName(); // prefer human-readable name
 						break;
 					}
 				}

--- a/Sources/Gui/MainScreenHelper.cpp
+++ b/Sources/Gui/MainScreenHelper.cpp
@@ -424,6 +424,8 @@ namespace spades {
 				for (const auto& item : result->list) {
 					if (item->GetAddress() == hostname) {
 						g_pendingServerName = item->GetName(); // prefer human-readable name
+						if (g_pendingMapName.empty())
+							g_pendingMapName = item->GetMapName(); // resolve from cached list
 						break;
 					}
 				}

--- a/Sources/Gui/MainScreenHelper.cpp
+++ b/Sources/Gui/MainScreenHelper.cpp
@@ -29,6 +29,7 @@
 
 #include "MainScreen.h"
 #include "MainScreenHelper.h"
+#include <Client/DemoRecorder.h>
 #include <Core/FileManager.h>
 #include <Core/IStream.h>
 #include <Core/Settings.h>
@@ -432,6 +433,23 @@ namespace spades {
 			if (result == NULL)
 				return "";
 			return result->message;
+		}
+
+		CScriptArray *MainScreenHelper::GetDemoList() {
+			auto recordings = client::DemoRecorder::ListRecordings();
+			asIScriptEngine *eng = ScriptManager::GetInstance()->GetEngine();
+			asITypeInfo *t = eng->GetTypeInfoByDecl("array<string>");
+			SPAssert(t != NULL);
+			CScriptArray *arr = CScriptArray::Create(t, static_cast<asUINT>(recordings.size()));
+			for (size_t i = 0; i < recordings.size(); i++)
+				arr->SetValue((asUINT)i, &recordings[i]);
+			return arr;
+		}
+
+		std::string MainScreenHelper::PlayDemo(std::string filename) {
+			if (mainScreen == NULL)
+				return "mainScreen == NULL";
+			return mainScreen->PlayDemo(filename);
 		}
 
 		std::string MainScreenHelper::GetPendingErrorMessage() {

--- a/Sources/Gui/MainScreenHelper.h
+++ b/Sources/Gui/MainScreenHelper.h
@@ -114,6 +114,7 @@ namespace spades {
 		CScriptArray *GetDemoList();
 		std::string PlayDemo(std::string filename);
 		int64_t GetDemoFileSize(std::string filename);
+		bool DeleteDemo(std::string filename);
 		};
 	}
 }

--- a/Sources/Gui/MainScreenHelper.h
+++ b/Sources/Gui/MainScreenHelper.h
@@ -110,6 +110,9 @@ namespace spades {
 			std::string GetPendingErrorMessage();
 
 			std::string GetCredits();
+
+		CScriptArray *GetDemoList();
+		std::string PlayDemo(std::string filename);
 		};
 	}
 }

--- a/Sources/Gui/MainScreenHelper.h
+++ b/Sources/Gui/MainScreenHelper.h
@@ -113,6 +113,7 @@ namespace spades {
 
 		CScriptArray *GetDemoList();
 		std::string PlayDemo(std::string filename);
+		int64_t GetDemoFileSize(std::string filename);
 		};
 	}
 }

--- a/Sources/Gui/MainScreenHelper.h
+++ b/Sources/Gui/MainScreenHelper.h
@@ -106,7 +106,7 @@ namespace spades {
 			CScriptArray *GetServerList(std::string sortKey, bool descending);
 			std::string GetServerListQueryMessage();
 			int GetServerPing(std::string address);
-			std::string ConnectServer(std::string hostname, int protocolVersion);
+			std::string ConnectServer(std::string hostname, int protocolVersion, std::string mapName = "");
 			std::string GetPendingErrorMessage();
 
 			std::string GetCredits();

--- a/Sources/Gui/StartupScreenHelper.cpp
+++ b/Sources/Gui/StartupScreenHelper.cpp
@@ -23,6 +23,11 @@
 #include <cctype>
 #include <regex>
 #include <utility>
+#ifdef WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#endif
 
 #include <Imports/OpenGL.h> //for gpu info
 #include <Imports/SDL.h>
@@ -653,6 +658,24 @@ namespace spades {
 				SPLog("Cannot open the user resource directory: g_userResourceDirectory is empty.");
 				return false;
 			}
+
+			return ShowDirectoryInShell(path);
+		}
+
+		bool StartupScreenHelper::BrowseDemosDirectory() {
+			std::string base = g_userResourceDirectory;
+			if (base.empty()) {
+				SPLog("Cannot open the demos directory: g_userResourceDirectory is empty.");
+				return false;
+			}
+
+			// Ensure the Demos directory exists before trying to open it.
+			std::string path = base + "/Demos";
+#ifdef WIN32
+			_mkdir(path.c_str());
+#else
+			mkdir(path.c_str(), 0755);
+#endif
 
 			return ShowDirectoryInShell(path);
 		}

--- a/Sources/Gui/StartupScreenHelper.h
+++ b/Sources/Gui/StartupScreenHelper.h
@@ -99,6 +99,7 @@ namespace spades {
 
 			std::string GetOperatingSystemType();
 			bool BrowseUserDirectory();
+			bool BrowseDemosDirectory();
 			bool OpenLinkInBrowser(const std::string& url);
 
 			void Start();

--- a/Sources/ScriptBindings/ClientUIHelper.cpp
+++ b/Sources/ScriptBindings/ClientUIHelper.cpp
@@ -66,6 +66,10 @@ namespace spades {
 						  "ClientUIHelper", "void AlertError(const string& in)",
 						  asMETHOD(ClientUIHelper, AlertError), asCALL_THISCALL);
 						manager->CheckError(r);
+						r = eng->RegisterObjectMethod(
+						  "ClientUIHelper", "bool IsDemoMode() const",
+						  asMETHOD(ClientUIHelper, IsDemoMode), asCALL_THISCALL);
+						manager->CheckError(r);
 						break;
 					default: break;
 				}

--- a/Sources/ScriptBindings/MainScreenHelper.cpp
+++ b/Sources/ScriptBindings/MainScreenHelper.cpp
@@ -93,6 +93,10 @@ namespace spades {
 					                              asMETHOD(gui::MainScreenHelper, PlayDemo),
 					                              asCALL_THISCALL);
 					manager->CheckError(r);
+					r = eng->RegisterObjectMethod("MainScreenHelper", "int64 GetDemoFileSize(string)",
+					                              asMETHOD(gui::MainScreenHelper, GetDemoFileSize),
+					                              asCALL_THISCALL);
+					manager->CheckError(r);
 					r = eng->RegisterObjectBehaviour(
 					  "MainScreenServerItem", asBEHAVE_ADDREF, "void f()",
 					  asMETHOD(gui::MainScreenServerItem, AddRef), asCALL_THISCALL);

--- a/Sources/ScriptBindings/MainScreenHelper.cpp
+++ b/Sources/ScriptBindings/MainScreenHelper.cpp
@@ -74,7 +74,7 @@ namespace spades {
 					                              asCALL_THISCALL);
 					manager->CheckError(r);
 					r = eng->RegisterObjectMethod(
-					  "MainScreenHelper", "string ConnectServer(string, int)",
+					  "MainScreenHelper", "string ConnectServer(string, int, string)",
 					  asMETHOD(gui::MainScreenHelper, ConnectServer), asCALL_THISCALL);
 					manager->CheckError(r);
 					r = eng->RegisterObjectMethod(

--- a/Sources/ScriptBindings/MainScreenHelper.cpp
+++ b/Sources/ScriptBindings/MainScreenHelper.cpp
@@ -85,6 +85,14 @@ namespace spades {
 					                              asMETHOD(gui::MainScreenHelper, GetCredits),
 					                              asCALL_THISCALL);
 					manager->CheckError(r);
+					r = eng->RegisterObjectMethod("MainScreenHelper", "array<string>@ GetDemoList()",
+					                              asMETHOD(gui::MainScreenHelper, GetDemoList),
+					                              asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod("MainScreenHelper", "string PlayDemo(string)",
+					                              asMETHOD(gui::MainScreenHelper, PlayDemo),
+					                              asCALL_THISCALL);
+					manager->CheckError(r);
 					r = eng->RegisterObjectBehaviour(
 					  "MainScreenServerItem", asBEHAVE_ADDREF, "void f()",
 					  asMETHOD(gui::MainScreenServerItem, AddRef), asCALL_THISCALL);

--- a/Sources/ScriptBindings/MainScreenHelper.cpp
+++ b/Sources/ScriptBindings/MainScreenHelper.cpp
@@ -97,6 +97,10 @@ namespace spades {
 					                              asMETHOD(gui::MainScreenHelper, GetDemoFileSize),
 					                              asCALL_THISCALL);
 					manager->CheckError(r);
+					r = eng->RegisterObjectMethod("MainScreenHelper", "bool DeleteDemo(string)",
+					                              asMETHOD(gui::MainScreenHelper, DeleteDemo),
+					                              asCALL_THISCALL);
+					manager->CheckError(r);
 					r = eng->RegisterObjectBehaviour(
 					  "MainScreenServerItem", asBEHAVE_ADDREF, "void f()",
 					  asMETHOD(gui::MainScreenServerItem, AddRef), asCALL_THISCALL);

--- a/Sources/ScriptBindings/StartupScreenHelper.cpp
+++ b/Sources/ScriptBindings/StartupScreenHelper.cpp
@@ -118,6 +118,10 @@ namespace spades {
 					  asMETHOD(gui::StartupScreenHelper, BrowseUserDirectory), asCALL_THISCALL);
 					manager->CheckError(r);
 					r = eng->RegisterObjectMethod(
+					  "StartupScreenHelper", "bool BrowseDemosDirectory()",
+					  asMETHOD(gui::StartupScreenHelper, BrowseDemosDirectory), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
 					  "StartupScreenHelper", "bool OpenLinkInBrowser(const string&in)",
 					  asMETHOD(gui::StartupScreenHelper, OpenLinkInBrowser), asCALL_THISCALL);
 					manager->CheckError(r);


### PR DESCRIPTION
This is a full demo recording and playback system, compatible with the aos_replay format. It has NOT been tested against files from other recorders (no active testers available).

Tested on macOS M4 (arm).

---

## Recording

Demos are recorded automatically on server join when enabled, or manually at any time with **F9** (also rebindable via `cg_keyDemoRecord` in Preferences → Controls). A blinking **● REC** label appears top-right of the screen (below the minimap) while recording is active.

Demo filenames encode context at record time:
YYYY-MM-DD-HH-MM-<server>-<map>-<gamemode>.dem


Example: `2026-03-29-13-46-voxide_tower_of_babel-ctf.dem`

Map names are resolved from the master server list at connect time — available whether you join from the server browser or by typing an address manually, as long as a server list fetch has succeeded at least once in the session. If unreachable, the map field is omitted.

Demos are stored in the OS user data directory (same folder as config and screenshots), not next to the binary.

---

## Playback

Demos are launched from the **Demos** tab in the main menu.

### Controls during playback

| Key | Action |
|-----|--------|
| `P` | Pause / Resume |
| `,` | Slow down (steps: 0.25× / 0.5× / 1×) |
| `.` | Speed up (steps: 1× / 2× / 4×) |
| `←` / `→` | Seek backward / forward 5 s (hold to accumulate) |

All keys are rebindable. Holding a seek key previews the target position cheaply (position-only), and commits the full seek on release.

---

## Demos Tab (Main Menu)

A new **Demos** tab sits alongside the server list, presenting recorded demos in a structured table:

**Server · Map · Mode · Timestamp · Size**

- Single-click a row to select it — the filename appears in the display field at the top.
- Double-click (or click **Play**) to launch the demo.
- **Delete** removes the file immediately and refreshes the list.
- Filenames that don't match the structured format display gracefully as plain names.

---

## Recording Settings (Startup Screen → Generic Tab)

Demo recording settings live in the **Generic** tab of the startup screen:

| Setting | Description | Default |
|---------|-------------|---------|
| `cg_demoAutoRecord` | Automatically start recording on every server join | Off |
| `cg_demoAutoPrune` | Delete oldest demos when the stored count exceeds the limit | On |
| `cg_demoMaxFiles` | How many demos to keep when auto-delete is active | 10 |
| Reveal Demos Folder | Opens the demos directory in Finder / Explorer / file manager | — |

The demos folder is created automatically on first use.

---

## Architecture

- `INetClient` interface introduced so `NetClient` (live) and `DemoNetClient` (playback) are interchangeable — no dual-dispatch flag in `Client`.
- Shared protocol constants extracted to `NetProtocol.h`.
- Backward seek is implemented via world snapshot reset + fast-replay; sounds and effects are suppressed during fast-replay.
- `SeekPreview` provides a cheap position-only preview while a seek key is held; the full `Seek()` commits on key release.
- `GameMap::Clone()` skips the default 66 MB zero-fill to avoid redundant allocation during seek.