### PR TITLE
Fix Setup-screen Reset-all silently wiping in-game-only cvars

### DIFF
--- a/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
+++ b/Resources/Scripts/Gui/StartupScreen/ConfigViewTabs.as
@@ -800,6 +800,11 @@ namespace spades {
 			string[]@ names = GetAllConfigNames();
 			for (uint i = 0, count = names.length; i < count; i++) {
 				ConfigItem item(names[i]);
+				// Skip cvars whose default isn't registered yet (in-game-only
+				// screens declare their defaults lazily). Without this guard,
+				// item.DefaultValue would be "" and we'd wipe the user's value.
+				if (item.IsUnknown)
+					continue;
 				item.StringValue = item.DefaultValue;
 			}
 


### PR DESCRIPTION
The Setup screen's "Reset all settings" button was overwriting cvars
whose defaults aren't registered yet at Setup time — wiping them to
the empty string instead of resetting them.

So now we will skip those when resetting... So they get preserved.

i.e. resetting the config will every time make the crosshairs transparent. Which is painful.
This is kind of a workaround though.


