### PR TITLE
add --try-mod and store where zerospades is into a cvar

### DIFF
--- a/Resources/Scripts/Gui/MainScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/MainScreen/MainMenu.as
@@ -594,7 +594,10 @@ namespace spades {
 					AddChild(tabStrip);
 					tabStrip.AddItem(_Tr("MainScreen", "Servers"), serverPanel);
 					tabStrip.AddItem(_Tr("MainScreen", "Demos"), demoPanel);
-					tabStrip.AddItem(_Tr("MainScreen", "Mods"), modsPanel);
+					// Hide the Mods tab while trying a single mod (--try-mod):
+					// the mod manager is irrelevant and its enabled set is bypassed.
+					if (!helper.IsTryingMod())
+						tabStrip.AddItem(_Tr("MainScreen", "Mods"), modsPanel);
 					@tabStrip.Changed = spades::ui::EventHandler(this.OnTabChanged);
 				}
 

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -717,6 +717,11 @@ namespace spades {
 				renderer->SetFogColor(MakeVector3(0, 0, 0));
 			}
 
+			// Auto-follow a player for menuless demo replay, before the scene is
+			// composed so the follow camera takes effect on the rendered frame.
+			if (demoReplayFollowPending)
+				UpdateDemoReplayFollow();
+
 			chatWindow->Update(dt);
 			killfeedWindow->Update(dt);
 			limbo->Update(dt);
@@ -769,6 +774,74 @@ namespace spades {
 			// Well done!
 			renderer->FrameDone();
 			renderer->Flip();
+		}
+
+		void Client::EnableDemoReplayFollow(const std::string& playerSpec) {
+			demoReplayFollowPending = true;
+			demoReplayFollowSpec = playerSpec;
+		}
+
+		int Client::ResolveDemoPlayer(const std::string& spec) {
+			if (!world)
+				return -1;
+
+			size_t slots = world->GetNumPlayerSlots();
+
+			if (!spec.empty()) {
+				// A purely numeric spec is treated as a player id (slot index).
+				bool numeric = true;
+				for (char c : spec) {
+					if (c < '0' || c > '9') {
+						numeric = false;
+						break;
+					}
+				}
+				if (numeric) {
+					int id = std::atoi(spec.c_str());
+					if (id >= 0 && (size_t)id < slots && world->GetPlayer((unsigned int)id))
+						return id;
+					SPLog("Demo: player id %s not present, using first player", spec.c_str());
+				} else {
+					for (size_t i = 0; i < slots; i++) {
+						auto p = world->GetPlayer((unsigned int)i);
+						if (p && p->GetName() == spec)
+							return (int)i;
+					}
+					SPLog("Demo: player named '%s' not found, using first player", spec.c_str());
+				}
+			}
+
+			// Default / fallback: first player that is on a team (not a spectator),
+			// since spectators have no body to watch.
+			for (size_t i = 0; i < slots; i++) {
+				auto p = world->GetPlayer((unsigned int)i);
+				if (p && !p->IsSpectator())
+					return (int)i;
+			}
+
+			// All occupied slots are spectators; fall back to the first one.
+			for (size_t i = 0; i < slots; i++) {
+				if (world->GetPlayer((unsigned int)i))
+					return (int)i;
+			}
+			return -1;
+		}
+
+		void Client::UpdateDemoReplayFollow() {
+			if (!world || !demoNet || activeNet->GetStatus() != NetClientStatusConnected)
+				return;
+
+			// Wait until at least one player exists, then follow it. ResolveDemoPlayer
+			// returns -1 while the world has no players, so this stays pending across
+			// the first frames of playback without ever blocking.
+			int pid = ResolveDemoPlayer(demoReplayFollowSpec);
+			if (pid < 0)
+				return;
+
+			followedPlayerId = pid;
+			followCameraState.enabled = true;
+			followCameraState.firstPerson = true;
+			demoReplayFollowPending = false;
 		}
 
 		bool Client::HasLocalPlayer() {

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -122,6 +122,12 @@ namespace spades {
 			float demoSeekPendingTime = 0.0F;   // target time to commit on key release
 			bool demoHudVisible = true;
 
+			// Automated one-shot follow for menuless demo replay (--replay-demo):
+			// once the world has loaded the requested player is followed. Unused
+			// unless EnableDemoReplayFollow() has been called.
+			bool demoReplayFollowPending = false;
+			std::string demoReplayFollowSpec; // empty = first player; else id or name
+
 			std::string playerName;
 			std::unique_ptr<IStream> logStream;
 
@@ -504,6 +510,10 @@ namespace spades {
 			std::string ScreenShotPath();
 			void TakeScreenShot(bool sceneOnly, bool scoreboardOnly = false);
 
+			// Demo helpers (see EnableDemoReplayFollow).
+			void UpdateDemoReplayFollow();
+			int ResolveDemoPlayer(const std::string& spec);
+
 			std::string BuildDemoContext();
 
 			std::string MapShotPath();
@@ -523,6 +533,14 @@ namespace spades {
 			bool IsDemoMode() const { return demoNet != nullptr; }
 			DemoNetClient* GetDemoNetClient() { return demoNet.get(); }
 			void ReloadDemo();
+
+			/**
+			 * Auto-follows a player once the demo world has loaded (empty = first
+			 * player; otherwise a player id or name) and keeps normal playback
+			 * running. Used by menuless demo replay (--replay-demo). Only
+			 * meaningful when the client was created with a demo path.
+			 */
+			void EnableDemoReplayFollow(const std::string& playerSpec);
 
 			void RunFrame(float dt) override;
 			void RunFrameLate(float dt) override;

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm> //std::sort
 #include <cstdio>
+#include <cstdlib>
 #include <memory>
 #include <regex>
 #include <sys/stat.h>
@@ -66,6 +67,11 @@ FILE __iob_func[3] = {*stdin, *stdout, *stderr};
 #endif
 
 DEFINE_SPADES_SETTING(cl_showStartupWindow, "1");
+
+// Absolute path of the running executable, refreshed every launch. Persisted
+// so external tooling (e.g. the mod workbench) can locate the binary without
+// guessing the platform's bundle layout.
+DEFINE_SPADES_SETTING(core_executablePath, "");
 
 #ifdef WIN32
 // windows.h must be included before DbgHelp.h and shlobj.h.
@@ -649,6 +655,26 @@ int main(int argc, char** argv) {
 
 		// load preferences.
 		spades::Settings::GetInstance()->Load();
+
+		// record the absolute executable path (overwrites any stale value from
+		// a previous launch, then gets flushed back to the config at shutdown).
+		// Windows: query the loaded module directly; POSIX: resolve argv[0]
+		// (symlinks and relative paths included) with realpath.
+		{
+			std::string exePath = spades::g_executablePath;
+#ifdef _WIN32
+			std::vector<wchar_t> wbuf(32768);
+			DWORD n = GetModuleFileNameW(NULL, wbuf.data(), (DWORD)wbuf.size());
+			if (n > 0 && n < wbuf.size())
+				exePath = Utf8FromWString(wbuf.data());
+#else
+			if (char* resolved = realpath(spades::g_executablePath.c_str(), nullptr)) {
+				exePath = resolved;
+				free(resolved);
+			}
+#endif
+			core_executablePath = exePath;
+		}
 		pumpEvents();
 
 		// dump CPU info (for debugging?)

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -38,6 +38,7 @@
 #include "Runner.h"
 #include "SplashWindow.h"
 #include <Client/Client.h>
+#include <Client/DemoRecorder.h>
 #include <Client/Fonts.h>
 #include <Client/GameMap.h>
 #include <Core/ConcurrentDispatch.h>
@@ -196,6 +197,14 @@ namespace {
 	bool g_replayDemo = false;
 	std::string g_replayDemoPath;
 
+	// Demo selection for --replay-demo, set with --demo and --player.
+	std::string g_demoPath;             // empty = latest demo in Demos/
+	std::string g_demoPlayer;           // empty = first player; else id or name
+
+	// Menuless demo replay (--replay-demo). Plays a demo and auto-follows a player,
+	// skipping the startup/setup/main screens entirely.
+	bool g_replayDemoMenuless = false;
+
 	bool g_printVersion = false;
 	bool g_printHelp = false;
 
@@ -227,6 +236,11 @@ namespace {
 		printf("                       set a config variable for this run only; the\n");
 		printf("                       on-disk config is left unchanged. May be given\n");
 		printf("                       multiple times.\n");
+		printf("  --replay-demo        play a demo and follow a player, skipping all\n");
+		printf("                       menus. Use --demo and --player to customise it.\n");
+		printf("  --demo FILE          demo to use (default: latest in Demos/); a bare\n");
+		printf("                       name resolves under Demos/\n");
+		printf("  --player ID|NAME     player to follow (default: first player)\n");
 		printf("  -h, --help           show this help message\n");
 		printf("  -v, --version        show version information\n");
 		printf("\nAuto-recording can be enabled with the cg_demoAutoRecord setting.\n");
@@ -299,6 +313,24 @@ namespace {
 				}
 				return 0;
 			}
+			if (!strcasecmp(a, "--replay-demo")) {
+				g_replayDemoMenuless = true;
+				return ++i;
+			}
+			if (!strcasecmp(a, "--demo")) {
+				if (i + 1 < argc) {
+					g_demoPath = argv[++i];
+					return ++i;
+				}
+				return 0;
+			}
+			if (!strcasecmp(a, "--player")) {
+				if (i + 1 < argc) {
+					g_demoPlayer = argv[++i];
+					return ++i;
+				}
+				return 0;
+			}
 		}
 
 		return 0;
@@ -334,6 +366,23 @@ namespace {
 				return c;
 		}
 		return std::string();
+	}
+
+	// Resolve the demo to use for --replay-demo. An explicit --demo value is used
+	// as-is (a bare name resolves under Demos/); otherwise the most recent
+	// recording is chosen. Returns "" if none is found.
+	std::string resolveCliDemoPath(const std::string& explicitPath) {
+		if (!explicitPath.empty()) {
+			if (explicitPath.find('/') == std::string::npos &&
+			    explicitPath.find('\\') == std::string::npos)
+				return "Demos/" + explicitPath;
+			return explicitPath;
+		}
+
+		auto demos = spades::client::DemoRecorder::ListRecordings();
+		if (demos.empty())
+			return std::string();
+		return demos.back();
 	}
 } // namespace
 
@@ -383,6 +432,31 @@ namespace spades {
 		DemoRunner runner(demoPath);
 		runner.RunProtected();
 	}
+
+	void StartDemoReplayAutoFollow(const std::string& demoPath, const std::string& playerSpec) {
+		class DemoRunner : public spades::gui::Runner {
+			std::string demoPath;
+			std::string playerSpec;
+
+		protected:
+			spades::gui::View* CreateView(spades::client::IRenderer* renderer,
+			                              spades::client::IAudioDevice* audio) override {
+				auto fontManager = Handle<client::FontManager>::New(renderer);
+				auto innerView = Handle<client::Client>::New(
+				    renderer, audio, ServerAddress(), fontManager, demoPath);
+				innerView->EnableDemoReplayFollow(playerSpec);
+				return new spades::gui::ConsoleScreen(renderer, audio, fontManager,
+				                                      std::move(innerView).Cast<gui::View>());
+			}
+
+		public:
+			DemoRunner(const std::string& demoPath, const std::string& playerSpec)
+			    : demoPath(demoPath), playerSpec(playerSpec) {}
+		};
+		DemoRunner runner(demoPath, playerSpec);
+		runner.RunProtected();
+	}
+
 	void StartMainScreen() {
 		class ConcreteRunner : public spades::gui::Runner {
 		protected:
@@ -906,7 +980,17 @@ int main(int argc, char** argv) {
 		pumpEvents();
 
 		// everything is now ready!
-		if (g_replayDemo) {
+		if (g_replayDemoMenuless) {
+			splashWindow.reset();
+
+			std::string demoPath = resolveCliDemoPath(g_demoPath);
+			if (demoPath.empty()) {
+				SPLog("No demos found in Demos/ for --replay-demo");
+			} else {
+				SPLog("Starting menuless demo replay: '%s'", demoPath.c_str());
+				spades::StartDemoReplayAutoFollow(demoPath, g_demoPlayer);
+			}
+		} else if (g_replayDemo) {
 			splashWindow.reset();
 
 			SPLog("Starting demo replay: %s", g_replayDemoPath.c_str());

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -23,8 +23,12 @@
 #include <cstdlib>
 #include <memory>
 #include <regex>
+#include <set>
+#include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <utility>
+#include <vector>
 
 #include <Imports/SDL.h>
 #include <zlib.h>
@@ -197,6 +201,16 @@ namespace {
 
 	std::string g_tryModPath;
 
+	// Config variable overrides requested on the command line via --override-cvar
+	// NAME=VALUE. Applied in memory after the preferences are loaded and reverted
+	// to their previous values before the config is written back, so the on-disk
+	// SPConfig.cfg is never modified by an override.
+	std::vector<std::pair<std::string, std::string>> g_cvarOverrides;
+
+	// Pre-override values of the variables in g_cvarOverrides, captured at apply
+	// time and written back before the config is flushed.
+	std::vector<std::pair<std::string, std::string>> g_cvarOverrideOriginals;
+
 	void printHelp(char* binaryName) {
 		printf("usage: %s [server_address] [v=protocol_version] [--replay demo.dem] [-h|--help] [-v|--version]\n",
 		       binaryName);
@@ -209,6 +223,10 @@ namespace {
 		printf("                       enabled-mod set, and hides the Mods tab, so\n");
 		printf("                       only this mod applies. A bare name resolves\n");
 		printf("                       under the user Mods/ folder.\n");
+		printf("  --override-cvar NAME=VALUE\n");
+		printf("                       set a config variable for this run only; the\n");
+		printf("                       on-disk config is left unchanged. May be given\n");
+		printf("                       multiple times.\n");
 		printf("  -h, --help           show this help message\n");
 		printf("  -v, --version        show version information\n");
 		printf("\nAuto-recording can be enabled with the cg_demoAutoRecord setting.\n");
@@ -258,6 +276,25 @@ namespace {
 				if (i + 1 < argc) {
 					spades::g_tryMod = true;
 					g_tryModPath = argv[++i];
+					return ++i;
+				}
+				return 0;
+			}
+			if (!strcasecmp(a, "--override-cvar")) {
+				if (i + 1 < argc) {
+					std::string spec = argv[++i];
+					auto eq = spec.find('=');
+					if (eq != std::string::npos) {
+						std::string name = spec.substr(0, eq);
+						std::string value = spec.substr(eq + 1);
+						if (!name.empty())
+							g_cvarOverrides.emplace_back(name, value);
+						else
+							SPLog("Ignoring --override-cvar with empty name: %s", spec.c_str());
+					} else {
+						SPLog("Ignoring malformed --override-cvar (expected NAME=VALUE): %s",
+						      spec.c_str());
+					}
 					return ++i;
 				}
 				return 0;
@@ -656,6 +693,32 @@ int main(int argc, char** argv) {
 		// load preferences.
 		spades::Settings::GetInstance()->Load();
 
+		// Apply --override-cvar values in memory. The previous value of each
+		// overridden variable is captured here and restored just before the
+		// config is flushed at shutdown, so an override never reaches the disk.
+		//
+		// Settings::Save() writes out every variable known to the instance, so
+		// referencing a brand-new name would add a stray line to the config.
+		// Only override variables that already exist (every real cvar is
+		// registered by static initializers before main runs); unknown names are
+		// skipped with a warning so the on-disk config is guaranteed untouched.
+		if (!g_cvarOverrides.empty()) {
+			auto knownNames = spades::Settings::GetInstance()->GetAllItemNames();
+			std::set<std::string> known(knownNames.begin(), knownNames.end());
+			for (const auto& ov : g_cvarOverrides) {
+				if (known.find(ov.first) == known.end()) {
+					SPLog("Ignoring --override-cvar for unknown config variable: %s",
+					      ov.first.c_str());
+					continue;
+				}
+				spades::Settings::ItemHandle item(ov.first, nullptr);
+				g_cvarOverrideOriginals.emplace_back(ov.first, (std::string)item);
+				item = ov.second;
+				SPLog("Overriding config variable for this run: %s = %s",
+				      ov.first.c_str(), ov.second.c_str());
+			}
+		}
+
 		// record the absolute executable path (overwrites any stale value from
 		// a previous launch, then gets flushed back to the config at shutdown).
 		// Windows: query the loaded module directly; POSIX: resolve argv[0]
@@ -866,6 +929,13 @@ int main(int argc, char** argv) {
 
 			spades::ServerAddress host(g_autoconnectHostName, g_autoconnectProtocolVersion);
 			spades::StartClient(host);
+		}
+
+		// Revert any --override-cvar values to what they were before this run so
+		// the flush below writes the unchanged configuration back to disk.
+		for (const auto& orig : g_cvarOverrideOriginals) {
+			spades::Settings::ItemHandle item(orig.first, nullptr);
+			item = orig.second;
 		}
 
 		spades::Settings::GetInstance()->Flush();

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -19,13 +19,11 @@
  */
 
 #include <algorithm> //std::sort
+#include <cstdio>
 #include <memory>
 #include <regex>
-
-#if (!defined(__APPLE__) && (__unix || __unix__)) || defined(__HAIKU__)
 #include <sys/stat.h>
 #include <sys/types.h>
-#endif
 
 #include <Imports/SDL.h>
 #include <zlib.h>
@@ -44,6 +42,7 @@
 #include <Core/FileManager.h>
 #include <Core/ServerAddress.h>
 #include <Core/Settings.h>
+#include <Core/StdStream.h>
 #include <Core/Strings.h>
 #include <Core/Thread.h>
 #include <Core/ZipFileSystem.h>
@@ -190,6 +189,8 @@ namespace {
 	bool g_printVersion = false;
 	bool g_printHelp = false;
 
+	std::string g_tryModPath;
+
 	void printHelp(char* binaryName) {
 		printf("usage: %s [server_address] [v=protocol_version] [--replay demo.dem] [-h|--help] [-v|--version]\n",
 		       binaryName);
@@ -197,6 +198,11 @@ namespace {
 		printf("  v=0.75 or v=0.76     protocol version (default: 0.75)\n");
 		printf("  --replay FILE        play back a demo recording\n");
 		printf("  -r FILE              play back a demo recording (short form)\n");
+		printf("  --try-mod PATH       try a mod (folder or .pak) on top of the base\n");
+		printf("                       game; bypasses the startup setup and the\n");
+		printf("                       enabled-mod set, and hides the Mods tab, so\n");
+		printf("                       only this mod applies. A bare name resolves\n");
+		printf("                       under the user Mods/ folder.\n");
 		printf("  -h, --help           show this help message\n");
 		printf("  -v, --version        show version information\n");
 		printf("\nAuto-recording can be enabled with the cg_demoAutoRecord setting.\n");
@@ -242,9 +248,49 @@ namespace {
 				spades::g_openModsTab = true;
 				return ++i;
 			}
+			if (!strcasecmp(a, "--try-mod")) {
+				if (i + 1 < argc) {
+					spades::g_tryMod = true;
+					g_tryModPath = argv[++i];
+					return ++i;
+				}
+				return 0;
+			}
 		}
 
 		return 0;
+	}
+
+	bool pathExists(const std::string& path) {
+		struct stat st;
+		return ::stat(path.c_str(), &st) == 0;
+	}
+
+	bool isDirectory(const std::string& path) {
+		struct stat st;
+		if (::stat(path.c_str(), &st) != 0)
+			return false;
+		return (st.st_mode & S_IFDIR) != 0;
+	}
+
+	// Resolve a --try-mod argument to a path on disk. Accepts a folder or a
+	// .pak/.zip file given directly (absolute or relative to the working dir),
+	// or a bare name that lives under the user Mods/ folder. Returns "" if
+	// nothing matches.
+	std::string resolveTryMod(const std::string& arg) {
+		if (pathExists(arg))
+			return arg;
+
+		const std::string& root = spades::g_userResourceDirectory;
+		std::string candidates[] = {
+		  root + "/Mods/" + arg,
+		  root + "/Mods/" + arg + ".pak",
+		};
+		for (const std::string& c : candidates) {
+			if (pathExists(c))
+				return c;
+		}
+		return std::string();
 	}
 } // namespace
 
@@ -252,6 +298,7 @@ namespace spades {
 	std::string g_userResourceDirectory;
 	std::string g_executablePath;
 	bool g_openModsTab = false;
+	bool g_tryMod = false;
 
 	void StartClient(const spades::ServerAddress& addr) {
 		class ConcreteRunner : public spades::gui::Runner {
@@ -704,7 +751,10 @@ int main(int argc, char** argv) {
 		// the base paks; the set is mounted in enabled order so the last-enabled
 		// mod ends up on top and wins conflicts. The shipped install paks are
 		// never modified — changes to the enabled set take effect on next launch.
-		{
+		//
+		// During a --try-mod run the enabled set is skipped entirely so the mod
+		// under test applies in isolation, on top of the base config only.
+		if (!spades::g_tryMod) {
 			std::vector<std::string> modPaks =
 			  spades::gui::ModsScreenHelper::GetEnabledModPakPaths();
 			for (const std::string& path : modPaks) {
@@ -716,6 +766,27 @@ int main(int argc, char** argv) {
 				} catch (const std::exception& ex) {
 					SPLog("Mod pak failed to mount: %s: %s", path.c_str(), ex.what());
 				}
+			}
+		}
+
+		// Mount the --try-mod target on top of everything. The target is an
+		// unpacked mod folder or a single .pak/.zip — both expose the same file
+		// tree, so the engine sees no difference between the two. No packing
+		// step, so editing files in the folder and relaunching is the whole loop.
+		if (spades::g_tryMod) {
+			std::string path = resolveTryMod(g_tryModPath);
+			if (path.empty()) {
+				SPLog("Mod to try not found: %s", g_tryModPath.c_str());
+			} else if (isDirectory(path)) {
+				spades::FileManager::PrependFileSystem(
+				  new spades::DirectoryFileSystem(path, false));
+				SPLog("Mod folder mounted: %s", path.c_str());
+			} else if (std::FILE* f = std::fopen(path.c_str(), "rb")) {
+				spades::FileManager::PrependFileSystem(
+				  new spades::ZipFileSystem(new spades::StdStream(f, true)));
+				SPLog("Mod pak mounted: %s", path.c_str());
+			} else {
+				SPLog("Mod to try failed to open: %s", path.c_str());
 			}
 		}
 		pumpEvents();
@@ -752,7 +823,7 @@ int main(int argc, char** argv) {
 			SPLog("Starting demo replay: %s", g_replayDemoPath.c_str());
 			spades::StartDemoReplay(g_replayDemoPath);
 		} else if (!g_autoconnect) {
-			if (spades::g_openModsTab ||
+			if (spades::g_openModsTab || spades::g_tryMod ||
 			    !((int)cl_showStartupWindow != 0 || splashWindow->IsStartupScreenRequested())) {
 				splashWindow.reset();
 

--- a/Sources/Gui/Main.h
+++ b/Sources/Gui/Main.h
@@ -34,6 +34,10 @@ namespace spades {
 	/** Set by --open-mods. Skips the startup window and selects the Mods tab. */
 	extern bool g_openModsTab;
 
+	/** Set by --try-mod. Mounts one mod in isolation, bypasses the startup
+	 * window and the enabled-mod set, and hides the Mods tab. */
+	extern bool g_tryMod;
+
 	void StartClient(const ServerAddress&);
 	void StartMainScreen();
 	void StartDemoReplay(const std::string& demoPath);

--- a/Sources/Gui/Main.h
+++ b/Sources/Gui/Main.h
@@ -42,6 +42,10 @@ namespace spades {
 	void StartMainScreen();
 	void StartDemoReplay(const std::string& demoPath);
 
+	/** Play back a demo and auto-follow a player, skipping all menus. playerSpec
+	 * selects the followed player (empty = first). Used by --replay-demo. */
+	void StartDemoReplayAutoFollow(const std::string& demoPath, const std::string& playerSpec);
+
 	/** Relaunch the program with --open-mods, then exit the current process. */
 	void RelaunchForMods();
 } // namespace spades

--- a/Sources/Gui/MainScreenHelper.cpp
+++ b/Sources/Gui/MainScreenHelper.cpp
@@ -476,6 +476,7 @@ namespace spades {
 		}
 
 		bool MainScreenHelper::ShouldOpenModsTab() { return spades::g_openModsTab; }
+		bool MainScreenHelper::IsTryingMod() { return spades::g_tryMod; }
 		void MainScreenHelper::RelaunchForMods() { spades::RelaunchForMods(); }
 
 		std::string MainScreenHelper::GetPendingErrorMessage() {

--- a/Sources/Gui/MainScreenHelper.h
+++ b/Sources/Gui/MainScreenHelper.h
@@ -118,6 +118,7 @@ namespace spades {
 			bool RenameDemo(const std::string& oldName, const std::string& newName);
 
 			bool ShouldOpenModsTab();
+			bool IsTryingMod();
 			void RelaunchForMods();
 		};
 	}

--- a/Sources/ScriptBindings/MainScreenHelper.cpp
+++ b/Sources/ScriptBindings/MainScreenHelper.cpp
@@ -109,6 +109,10 @@ namespace spades {
 					                              asMETHOD(gui::MainScreenHelper, ShouldOpenModsTab),
 					                              asCALL_THISCALL);
 					manager->CheckError(r);
+					r = eng->RegisterObjectMethod("MainScreenHelper", "bool IsTryingMod()",
+					                              asMETHOD(gui::MainScreenHelper, IsTryingMod),
+					                              asCALL_THISCALL);
+					manager->CheckError(r);
 					r = eng->RegisterObjectMethod("MainScreenHelper", "void RelaunchForMods()",
 					                              asMETHOD(gui::MainScreenHelper, RelaunchForMods),
 					                              asCALL_THISCALL);


### PR DESCRIPTION
- `--try-mod ` can load a mod as .pak or un uncompressed folder. Hides the mod tab, disable installed mods, only ur mod is tried.
- 'core_executablePath' car added. So[ external mod workbench](https://github.com/zerospades/ModWorkbench) can find zerospades to try mods.