### PR TITLE
Opengl fixes :)

### DIFF
--- a/Sources/Client/SceneDefinition.h
+++ b/Sources/Client/SceneDefinition.h
@@ -47,6 +47,15 @@ namespace spades {
 			float radialBlur;
 
 			SceneDefinition() {
+				viewportLeft = viewportTop = 0;
+				viewportWidth = viewportHeight = 0;
+				fovX = fovY = 0.0F;
+				viewOrigin = MakeVector3(0, 0, 0);
+				viewAxis[0] = MakeVector3(1, 0, 0);
+				viewAxis[1] = MakeVector3(0, 1, 0);
+				viewAxis[2] = MakeVector3(0, 0, 1);
+				zNear = zFar = 0.0F;
+				skipWorld = false;
 				depthOfFieldFocalLength = 0.0F;
 				depthOfFieldNearBlurStrength = 1.0F;
 				depthOfFieldFarBlurStrength = 0.0F;

--- a/Sources/Draw/OpenGL/GLBasicShadowMapRenderer.cpp
+++ b/Sources/Draw/OpenGL/GLBasicShadowMapRenderer.cpp
@@ -136,7 +136,7 @@ namespace spades {
 			               plane2.GetDistanceTo(base) / Vector3::Dot(dir, plane2.n));
 		}
 
-		void GLBasicShadowMapRenderer::BuildMatrix(float near, float far) {
+		bool GLBasicShadowMapRenderer::BuildMatrix(float near, float far) {
 			// TODO: variable light direction?
 			Vector3 lightDir = MakeVector3(0, -1, -1).Normalize();
 			// set better up dir?
@@ -194,9 +194,20 @@ namespace spades {
 			Vector3 axis2 = up * (maxY - minY);
 			Vector3 axis3 = lightDir * (seg.high - seg.low);
 
+			// Bail out if the camera frustum is degenerate (e.g. an uninitialized
+			// scene definition during a transition). A zero-length or non-finite
+			// axis would otherwise make the projection matrix non-finite, which
+			// silently passes frustum culling (NaN compares false) and corrupts
+			// shadow rendering.
+			float len1 = axis1.GetLength();
+			float len2 = axis2.GetLength();
+			float len3 = axis3.GetLength();
+			if (!(len1 > 1.0E-6F && len2 > 1.0E-6F && len3 > 1.0E-6F))
+				return false;
+
 			obb = OBB3(Matrix4::FromAxis(axis1, axis2, axis3, origin));
-			vpWidth = 2.f / axis1.GetLength();
-			vpHeight = 2.f / axis2.GetLength();
+			vpWidth = 2.f / len1;
+			vpHeight = 2.f / len2;
 
 			// convert to projectionview matrix
 			matrix = obb.m.InversedFast();
@@ -220,13 +231,13 @@ namespace spades {
 				// SPAssert(v.z < 1.f);
 			}
 #endif
+			return true;
 		}
 
 		void GLBasicShadowMapRenderer::Render() {
 			SPADES_MARK_FUNCTION();
 
-			// skip until the camera is initialized; a degenerate frustum would make
-			// BuildMatrix divide by a zero-length axis and produce a NaN matrix
+			// skip until the camera is initialized
 			const client::SceneDefinition& def = GetRenderer().GetSceneDef();
 			if (def.fovX <= 0.0F || def.fovY <= 0.0F)
 				return;
@@ -245,7 +256,10 @@ namespace spades {
 					case 2: farDist = 150.0F; break;
 				}
 
-				BuildMatrix(nearDist, farDist);
+				// skip shadow rendering this frame if the camera isn't usable yet
+				// (e.g. an uninitialized scene definition during a transition)
+				if (!BuildMatrix(nearDist, farDist))
+					return;
 				matrices[i] = matrix;
 
 				device.BindFramebuffer(IGLDevice::Framebuffer, framebuffer[i]);

--- a/Sources/Draw/OpenGL/GLBasicShadowMapRenderer.cpp
+++ b/Sources/Draw/OpenGL/GLBasicShadowMapRenderer.cpp
@@ -225,6 +225,12 @@ namespace spades {
 		void GLBasicShadowMapRenderer::Render() {
 			SPADES_MARK_FUNCTION();
 
+			// skip until the camera is initialized; a degenerate frustum would make
+			// BuildMatrix divide by a zero-length axis and produce a NaN matrix
+			const client::SceneDefinition& def = GetRenderer().GetSceneDef();
+			if (def.fovX <= 0.0F || def.fovY <= 0.0F)
+				return;
+
 			float nearDist = 0.0F;
 			for (int i = 0; i < NumSlices; i++) {
 				GLProfiler::Context profiler(GetRenderer().GetGLProfiler(), "Slice %d / %d", i + 1,

--- a/Sources/Draw/OpenGL/GLBasicShadowMapRenderer.h
+++ b/Sources/Draw/OpenGL/GLBasicShadowMapRenderer.h
@@ -46,7 +46,7 @@ namespace spades {
 			OBB3 obb;
 			float vpWidth, vpHeight; // used for culling
 
-			void BuildMatrix(float near, float far);
+			bool BuildMatrix(float near, float far);
 
 		public:
 			GLBasicShadowMapRenderer(GLRenderer &);

--- a/Sources/Draw/OpenGL/GLFramebufferManager.cpp
+++ b/Sources/Draw/OpenGL/GLFramebufferManager.cpp
@@ -389,6 +389,28 @@ namespace spades {
 			device.Viewport(0, 0, renderWidth, renderHeight);
 		}
 
+		void GLFramebufferManager::ResolveDepth() {
+			SPADES_MARK_FUNCTION();
+
+			// Only meaningful with MSAA: the scene renders into the multisampled depth
+			// buffer, but single-sample passes sample `renderDepthTexture`. Without this,
+			// SSAO reads a stale (previous-frame) depth, which combined with the
+			// volumetric fog produced shadows leaking through walls.
+			if (!useMultisample)
+				return;
+
+			// `useMultisample` implies `r_blitFramebuffer` (see the constructor), so the
+			// blit path is always available here.
+			int w = renderWidth;
+			int h = renderHeight;
+			device.BindFramebuffer(IGLDevice::ReadFramebuffer, multisampledFramebuffer);
+			device.BindFramebuffer(IGLDevice::DrawFramebuffer, renderFramebuffer);
+			device.BlitFramebuffer(0, 0, w, h, 0, 0, w, h, IGLDevice::DepthBufferBit,
+			                       IGLDevice::Nearest);
+			device.BindFramebuffer(IGLDevice::ReadFramebuffer, 0);
+			device.BindFramebuffer(IGLDevice::DrawFramebuffer, 0);
+		}
+
 		GLColorBuffer
 		GLFramebufferManager::PrepareForWaterRendering(IGLDevice::UInteger tempFb,
 		                                               IGLDevice::UInteger tempDepthTex) {

--- a/Sources/Draw/OpenGL/GLFramebufferManager.h
+++ b/Sources/Draw/OpenGL/GLFramebufferManager.h
@@ -102,6 +102,11 @@ namespace spades {
 			/** setups device for scene rendering. */
 			void PrepareSceneRendering();
 
+			/** Resolves the multisampled depth buffer into the single-sample depth
+			 * texture (a no-op when MSAA is disabled). Used so passes that sample
+			 * `GetDepthTexture()` mid-frame (e.g. SSAO) see the current depth. */
+			void ResolveDepth();
+
 			BufferHandle PrepareForWaterRendering(IGLDevice::UInteger tempFb,
 			                                      IGLDevice::UInteger tempDepthTex);
 			BufferHandle StartPostProcessing();

--- a/Sources/Draw/OpenGL/GLOptimizedVoxelModel.cpp
+++ b/Sources/Draw/OpenGL/GLOptimizedVoxelModel.cpp
@@ -334,7 +334,12 @@ namespace spades {
 								p3 += uu;
 								p3 += vv;
 							} else {
-								*(pixels++) = 0xFF00FF;
+								// No neighbouring voxel to take a color from. Extend the
+								// previous texel (or black) instead of stamping a magenta
+								// sentinel, so this unfilled padding doesn't bleed into the
+								// face edge under texture filtering.
+								*pixels = (x > 0) ? pixels[-1] : 0;
+								pixels++;
 								p2 += uu;
 								continue;
 							}

--- a/Sources/Draw/OpenGL/GLRenderer.cpp
+++ b/Sources/Draw/OpenGL/GLRenderer.cpp
@@ -605,6 +605,12 @@ namespace spades {
 				}
 
 				if (needsFullDepthPrepass) {
+					// Under MSAA the prepass rendered into the multisampled depth buffer,
+					// but SSAO samples the single-sample depth texture. Resolve it now (while
+					// depth writes are still enabled) so SSAO reads this frame's depth instead
+					// of a stale one — the cause of the fog+SSAO+MSAA shadow-through-walls bug.
+					GetFramebufferManager()->ResolveDepth();
+
 					{
 						GLProfiler::Context p(*profiler, "Screen Space Ambient Occlusion");
 

--- a/Sources/Draw/OpenGL/GLSparseShadowMapRenderer.cpp
+++ b/Sources/Draw/OpenGL/GLSparseShadowMapRenderer.cpp
@@ -147,7 +147,7 @@ namespace spades {
 			               plane2.GetDistanceTo(base) / Vector3::Dot(dir, plane2.n));
 		}
 
-		void GLSparseShadowMapRenderer::BuildMatrix(float near, float far) {
+		bool GLSparseShadowMapRenderer::BuildMatrix(float near, float far) {
 			client::SceneDefinition def = GetRenderer().GetSceneDef();
 
 			// TODO: variable light direction?
@@ -203,9 +203,20 @@ namespace spades {
 			Vector3 axis2 = up * (maxY - minY);
 			Vector3 axis3 = lightDir * (seg.high - seg.low);
 
+			// Bail out if the camera frustum is degenerate (e.g. an uninitialized
+			// scene definition during a transition). A zero-length or non-finite
+			// axis would otherwise make the projection matrix non-finite, which
+			// silently passes frustum culling (NaN compares false) and corrupts
+			// shadow rendering.
+			float len1 = axis1.GetLength();
+			float len2 = axis2.GetLength();
+			float len3 = axis3.GetLength();
+			if (!(len1 > 1.0E-6F && len2 > 1.0E-6F && len3 > 1.0E-6F))
+				return false;
+
 			obb = OBB3(Matrix4::FromAxis(axis1, axis2, axis3, origin));
-			vpWidth = 2.0F / axis1.GetLength();
-			vpHeight = 2.0F / axis2.GetLength();
+			vpWidth = 2.0F / len1;
+			vpHeight = 2.0F / len2;
 
 			// convert to projectionview matrix
 			matrix = obb.m.InversedFast();
@@ -227,6 +238,7 @@ namespace spades {
 				SPAssert(v.y < 1.0F);
 			}
 #endif
+			return true;
 		}
 
 		void GLSparseShadowMapRenderer::Render() {
@@ -238,7 +250,10 @@ namespace spades {
 			if (def.fovX <= 0.0F || def.fovY <= 0.0F)
 				return;
 
-			BuildMatrix(def.zNear, def.zFar);
+			// skip if the camera frustum is degenerate (BuildMatrix would otherwise
+			// produce a non-finite matrix that corrupts the shadow map)
+			if (!BuildMatrix(def.zNear, def.zFar))
+				return;
 
 			device.BindFramebuffer(IGLDevice::Framebuffer, framebuffer);
 			device.Viewport(0, 0, textureSize, textureSize);
@@ -489,11 +504,15 @@ namespace spades {
 						OBB3 instBoundsOBB = r.matrix * instWorldBoundsOBB;
 						AABB3 instBounds = instBoundsOBB.GetBoundingAABB();
 
-						// frustrum(?) cull
-						if (instBounds.max.x < -1.0F ||
-							instBounds.max.y < -1.0F ||
-						    instBounds.min.x > 1.0F ||
-							instBounds.min.y > 1.0F)
+						// Frustum cull. Written in positive logic so that a model with a
+						// non-finite (NaN) transform — which can be submitted during scene
+						// transitions before an entity is initialized — is rejected rather
+						// than kept (every comparison with NaN is false). The basic shadow
+						// renderer's SphereCull already drops such models the same way.
+						if (!(instBounds.max.x >= -1.0F &&
+							  instBounds.max.y >= -1.0F &&
+							  instBounds.min.x <= 1.0F &&
+							  instBounds.min.y <= 1.0F))
 							continue;
 
 						inst.tile1 = ShadowMapToTileCoord(instBounds.min);
@@ -629,6 +648,12 @@ namespace spades {
 			bool TryPack() {
 				size_t rootNode = NoNode;
 				nodes.clear();
+				// AddGroupToNode holds references (Node& and the size_t& child links)
+				// into `nodes` across recursive calls that push_back into it. Reserve
+				// enough up front so the vector never reallocates mid-recursion, which
+				// would dangle those references (benign on x86, heap corruption on arm64).
+				// Each group placement creates at most two nodes.
+				nodes.reserve(groups.size() * 2 + 1);
 				for (size_t i = 0; i < groups.size(); i++) {
 					if (!AddGroupToNode(rootNode, 0, 0, mapSize, mapSize, i))
 						return false;
@@ -757,17 +782,19 @@ namespace spades {
 						Internal::Instance& inst = itnl.allInstances[mId];
 						mrend.RenderModel(inst.model, *inst.param);
 
-						AABB3 modelBounds = inst.model->GetBoundingBox();
-						Vector3 v = modelBounds.min + modelBounds.max;
-						v *= 0.5F;
-						v = (inst.param->matrix * v).GetXYZ();
-						{
-							v = (baseMatrix * v).GetXYZ();
-							SPAssert(v.x >= -1.2F);
-							SPAssert(v.y >= -1.2F);
-							SPAssert(v.x <= 1.2F);
-							SPAssert(v.y <= 1.2F);
-						}
+						// Sanity-check that the packed instance overlaps the shadow map
+						// region, consistent with the build-time frustum cull. The cull
+						// keeps an instance by bounding-box overlap, so a model close to
+						// the camera near the frustum edge can have its center outside the
+						// region while its box still overlaps; test the projected box, not
+						// the center, to match the cull.
+						OBB3 modelBounds = inst.model->GetBoundingBox();
+						AABB3 shadowBounds =
+						  (baseMatrix * (inst.param->matrix * modelBounds)).GetBoundingAABB();
+						SPAssert(shadowBounds.max.x >= -1.2F);
+						SPAssert(shadowBounds.max.y >= -1.2F);
+						SPAssert(shadowBounds.min.x <= 1.2F);
+						SPAssert(shadowBounds.min.y <= 1.2F);
 					}
 					mrend.Flush();
 				}

--- a/Sources/Draw/OpenGL/GLSparseShadowMapRenderer.h
+++ b/Sources/Draw/OpenGL/GLSparseShadowMapRenderer.h
@@ -57,7 +57,7 @@ namespace spades {
 			OBB3 obb;
 			float vpWidth, vpHeight; // used for culling
 
-			void BuildMatrix(float near, float far);
+			bool BuildMatrix(float near, float far);
 
 		protected:
 			void RenderShadowMapPass() override;


### PR DESCRIPTION
Closes https://github.com/yvt/openspades/issues/862 and a few other things that have been annoying me for a while.

- Issue #862 — fog + SSAO + MSAA shadows-through-walls — fixed at the root (SSAO was sampling stale single-sample depth under MSAA; now resolved before the SSAO pass).

- Shadow-map crash hardening (3 commits): NaN model transform vs the sparse cull, degenerate-camera BuildMatrix guard, SceneDefinition init, packer nodes.reserve. Was really annoying on my Mac arm: sometimes, it was not possible to play at all.

- Magenta sight artifact — atlas padding sentinel on downscaled models. Occurred with some mods.
