### PR TITLE
Sw renderer optimizations

### DIFF
--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -353,9 +353,12 @@ namespace spades {
 			renderer->RegisterImage("Gfx/Killfeed/l-Domination.png");
 			renderer->RegisterImage("Gfx/Killfeed/m-Revenge.png");
 			renderer->RegisterImage("Gfx/Ball.png");
+			renderer->RegisterImage("Gfx/DotSight.tga");
 			renderer->RegisterImage("Gfx/HurtRing.png");
 			renderer->RegisterImage("Gfx/HurtSprite.png");
 			renderer->RegisterImage("Gfx/ReflexSight.png");
+			renderer->RegisterImage("Gfx/Rifle.png");
+			renderer->RegisterImage("Gfx/Sight.tga");
 			renderer->RegisterImage("Gfx/Spotlight.jpg");
 			renderer->RegisterImage("Gfx/White.tga");
 			renderer->RegisterImage("Textures/Fluid.png");

--- a/Sources/Core/Debug.cpp
+++ b/Sources/Core/Debug.cpp
@@ -194,6 +194,21 @@ namespace spades {
 	static bool attemptedToInitializeLog = false;
 	static std::string accumlatedLog;
 
+	// Buffered log-file writing: log lines are accumulated in memory and
+	// written to disk at most once per second (or when the buffer grows
+	// large). This keeps slow disk I/O (fflush, antivirus scans, network
+	// drives) from stalling the calling thread on every single log line.
+	static std::string pendingLogBuffer;
+	static time_t lastLogFlushTime = 0;
+
+	static void FlushPendingLog() {
+		if (logStream && !pendingLogBuffer.empty()) {
+			logStream->Write(pendingLogBuffer);
+			logStream->Flush();
+			pendingLogBuffer.clear();
+		}
+	}
+
 	void StartLog() {
 		attemptedToInitializeLog = true;
 		logStream = FileManager::OpenForWriting("SystemMessages.log");
@@ -204,6 +219,7 @@ namespace spades {
 
 	void StopLog() {
 		if (logStream) {
+			FlushPendingLog();
 			logStream->Flush();
 			logStream.reset(); // closes the underlying file handle
 		}
@@ -259,8 +275,13 @@ namespace spades {
 		// (2) The log file a.k.a. `SystemMessages.log`
 		if (logStream || !attemptedToInitializeLog) {
 			if (attemptedToInitializeLog) {
-				logStream->Write(outStr);
-				logStream->Flush();
+				pendingLogBuffer += outStr;
+				// Flush at most once per second, or when the buffer gets
+				// large. `t` was already obtained above for the timestamp.
+				if (t != lastLogFlushTime || pendingLogBuffer.size() >= 65536) {
+					lastLogFlushTime = t;
+					FlushPendingLog();
+				}
 			} else
 				accumlatedLog += buf;
 		}

--- a/Sources/Draw/SW/SWImageRenderer.cpp
+++ b/Sources/Draw/SW/SWImageRenderer.cpp
@@ -21,6 +21,7 @@
 #include "SWImageRenderer.h"
 #include "SWImage.h"
 #include <Core/Bitmap.h>
+#include <cstring>
 
 namespace spades {
 	namespace draw {
@@ -967,11 +968,29 @@ namespace spades {
 				__m128i mulInv = _mm_set1_epi16(256 - (mulA + (mulA >> 7)));
 				mulCol = _mm_slli_epi16(mulCol, 8);
 
-				auto drawPixel = [mulCol, mulInv](uint32_t& dest, float& destDepth, float inDepth) {
+				// When mulA == 255, mulInv is exactly 0, so the blend below already
+				// reduces mathematically to a plain overwrite. Precomputing the result
+				// and storing it directly skips the blend arithmetic without changing
+				// a single output bit.
+				const bool solidOpaque = (mulA == 255);
+				const uint32_t opaqueColor = static_cast<uint32_t>(mulB) |
+				                              (static_cast<uint32_t>(mulG) << 8) |
+				                              (static_cast<uint32_t>(mulR) << 16) |
+				                              (static_cast<uint32_t>(mulA) << 24);
+				const uint64_t opaqueColorPair =
+				  static_cast<uint64_t>(opaqueColor) | (static_cast<uint64_t>(opaqueColor) << 32);
+
+				auto drawPixel = [mulCol, mulInv, solidOpaque, opaqueColor](
+				                    uint32_t& dest, float& destDepth, float inDepth) {
 					if (depthTest) {
 						if (inDepth > destDepth) {
 							return;
 						}
+					}
+
+					if (solidOpaque) {
+						dest = opaqueColor;
+						return;
 					}
 
 					// load [u8.8x4]8bw
@@ -998,8 +1017,9 @@ namespace spades {
 					_mm_store_ss(reinterpret_cast<float*>(&dest), _mm_castsi128_ps(dcol));
 				};
 
-				auto drawPixel2 = [mulCol, mulInv, &drawPixel](uint32_t* dest, float* destDepth,
-				                                               float inDepth1, float inDepth2) {
+				auto drawPixel2 = [mulCol, mulInv, solidOpaque, opaqueColorPair,
+				                   &drawPixel](uint32_t* dest, float* destDepth,
+				                               float inDepth1, float inDepth2) {
 					if (depthTest) {
 						if (inDepth1 > destDepth[0]) {
 							drawPixel(dest[1], destDepth[1], inDepth2);
@@ -1009,6 +1029,11 @@ namespace spades {
 							drawPixel(dest[0], destDepth[0], inDepth2);
 							return;
 						}
+					}
+
+					if (solidOpaque) {
+						std::memcpy(dest, &opaqueColorPair, sizeof(opaqueColorPair));
+						return;
 					}
 
 					// load [u8.8 x 4 x 2]
@@ -1034,6 +1059,7 @@ namespace spades {
 					// store.
 					_mm_store_sd(reinterpret_cast<double*>(dest), _mm_castsi128_pd(dcol));
 				};
+
 
 				auto drawScanline = [bmp, fbW, depthBuffer, &drawPixel, &drawPixel2, &r](int y, int x1, int x2,
 					const SWImageVarying& vary1, const SWImageVarying& vary2, float z1, float z2) {

--- a/Sources/Draw/SW/SWMapRenderer.cpp
+++ b/Sources/Draw/SW/SWMapRenderer.cpp
@@ -383,9 +383,9 @@ namespace spades {
 			if (minPitch >= maxPitch)
 				return;
 
-			std::array<float, 65> zval; // precompute (z - cz) * some
-			for (size_t i = 0; i < zval.size(); i++)
-				zval[i] = (static_cast<float>(i) - cz);
+			std::uint_fast32_t emptyCount = static_cast<std::uint_fast32_t>(lineResolution);
+
+			const std::array<float, 65>& zval = frameZVal; // precomputed (z - cz)
 
 			float vmax = lineResolution + 0.5F;
 			auto transform = [&zval, &transOffset, vmax, &transScale](float invDist, int z) {
@@ -401,9 +401,7 @@ namespace spades {
 			// Z value -> view Z value factor
 			float heightScale = sceneDef.viewAxis[2].z;
 
-			std::array<float, 65> heightScaleVal; // precompute (heightScale * z)
-			for (size_t i = 0; i < zval.size(); i++)
-				heightScaleVal[i] = (static_cast<float>(i) * heightScale);
+			const std::array<float, 65>& heightScaleVal = frameHeightScaleVal;
 
 			float depthBias = -cz * heightScale;
 
@@ -582,14 +580,17 @@ namespace spades {
 							if (z > icz) {
 								std::uint_fast16_t p1 = transform(invDist, z);
 								std::uint_fast16_t p2 = transform(oldInvDist, z);
-								LinePixel px = BuildLinePixel(oirx, oiry, z,
-									Face::NegZ, medDist + heightScaleVal[z]);
+								if (p1 < p2) {
+									LinePixel px = BuildLinePixel(oirx, oiry, z,
+										Face::NegZ, medDist + heightScaleVal[z]);
 
-								for (std::uint_fast16_t j = p1; j < p2; j++) {
-									auto& p = pixels[j];
-									if (!p.IsEmpty())
-										continue;
-									p.Set(px);
+									for (std::uint_fast16_t j = p1; j < p2; j++) {
+										auto& p = pixels[j];
+										if (!p.IsEmpty())
+											continue;
+										p.Set(px);
+										emptyCount--;
+									}
 								}
 							}
 							ptr++;
@@ -600,14 +601,17 @@ namespace spades {
 							if (z < icz) {
 								std::uint_fast16_t p1 = transform(invDist, z + 1);
 								std::uint_fast16_t p2 = transform(oldInvDist, z + 1);
-								LinePixel px = BuildLinePixel(oirx, oiry, z,
-									Face::PosZ, medDist + heightScaleVal[z + 1]);
+								if (p2 < p1) {
+									LinePixel px = BuildLinePixel(oirx, oiry, z,
+										Face::PosZ, medDist + heightScaleVal[z + 1]);
 
-								for (std::uint_fast16_t j = p2; j < p1; j++) {
-									auto& p = pixels[j];
-									if (!p.IsEmpty())
-										continue;
-									p.Set(px);
+									for (std::uint_fast16_t j = p2; j < p1; j++) {
+										auto& p = pixels[j];
+										if (!p.IsEmpty())
+											continue;
+										p.Set(px);
+										emptyCount--;
+									}
 								}
 							}
 							ptr++;
@@ -638,17 +642,25 @@ namespace spades {
 						savedZ = z + 1;
 						savedP = p2;
 
-						LinePixel px = BuildLinePixel(irx, iry, z, wallFace, medDist + heightScaleVal[z]);
+						if (p1 < p2) {
+							LinePixel px =
+							  BuildLinePixel(irx, iry, z, wallFace, medDist + heightScaleVal[z]);
 
-						for (std::uint_fast16_t j = p1; j < p2; j++) {
-							auto& p = pixels[j];
-							if (!p.IsEmpty())
-								continue;
-							p.Set(px);
+							for (std::uint_fast16_t j = p1; j < p2; j++) {
+								auto& p = pixels[j];
+								if (!p.IsEmpty())
+									continue;
+								p.Set(px);
+								emptyCount--;
+							}
 						}
 					}
 
 				} // add wall - end
+
+				// every pixel of this line written; nothing more can appear
+				if (emptyCount == 0)
+					break;
 
 				// check pitch cull
 				if ((--count) == 0) {
@@ -754,13 +766,9 @@ namespace spades {
 					uint32_t* fb2 = fb + fx + fy * fw;
 					float* db2 = depthBuf + fx + fy * fw;
 
-					if (v2.z > 0.99F || v2.z < -0.99F)
-						goto FastBlockPath; // near to pole. cannot be approximated by piecewise
-
-				FastBlockPath : {
 					// Use bi-linear interpolation for faster yaw/pitch
 					// computation.
-
+					{
 					auto calcYawindex = [yawMin2](Vector3 v) {
 						std::int32_t yawIndex;
 						{
@@ -808,23 +816,33 @@ namespace spades {
 						std::int32_t pitchC = pitchA;
 						std::int32_t pitchDelta = (pitchB - pitchA) / blockSize;
 
+						std::uint32_t cachedYawIndex = 0xFFFFFFFFu;
+						const LinePixel* pixels = nullptr;
+						std::int32_t cachedPitchTanMinI = 0;
+						std::int32_t cachedPitchScaleI = 0;
+
 						for (unsigned int y = 0; y < blockSize; y++) {
 							std::uint32_t yawIndex =
 							  static_cast<unsigned int>(yawIndexC << 8 >> 16);
 							yawIndex = (yawIndex * yawScale2) >> 16;
 							yawIndex = (yawIndex * numLines) >> 16;
-							auto& line = lineList[yawIndex];
-							auto* pixels = line.pixels.data();
+							if (yawIndex != cachedYawIndex) {
+								auto& line = lineList[yawIndex];
+								pixels = line.pixels.data();
+								cachedPitchTanMinI = line.pitchTanMinI;
+								cachedPitchScaleI = line.pitchScaleI;
+								cachedYawIndex = yawIndex;
+							}
 
 							// solve pitch
 							std::int32_t pitchIndex;
 
 							{
 								pitchIndex = pitchC >> 13;
-								pitchIndex -= line.pitchTanMinI;
+								pitchIndex -= cachedPitchTanMinI;
 								pitchIndex =
 								  static_cast<int>((static_cast<int64_t>(pitchIndex) *
-								                    static_cast<int64_t>(line.pitchScaleI)) >>
+								                    static_cast<int64_t>(cachedPitchScaleI)) >>
 								                   32);
 								// pitch = (pitch - line.pitchTanMin) * line.pitchScale;
 								// pitchIndex = static_cast<int>(pitch);
@@ -982,6 +1000,15 @@ namespace spades {
 					float y = horiz.x * s + horiz.y * c;
 					horiz.x = x;
 					horiz.y = y;
+				}
+			}
+
+			{
+				float cz = def.viewOrigin.z;
+				float heightScale = def.viewAxis[2].z;
+				for (size_t i = 0; i < frameZVal.size(); i++) {
+					frameZVal[i] = static_cast<float>(i) - cz;
+					frameHeightScaleVal[i] = static_cast<float>(i) * heightScale;
 				}
 			}
 

--- a/Sources/Draw/SW/SWMapRenderer.h
+++ b/Sources/Draw/SW/SWMapRenderer.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <vector>
 
@@ -57,6 +58,10 @@ namespace spades {
 			std::vector<size_t> rleLen;
 
 			int lineResolution;
+
+			// per-frame precomputed tables (shared read-only by BuildLine threads)
+			std::array<float, 65> frameZVal;
+			std::array<float, 65> frameHeightScaleVal;
 
 			typedef int8_t RleData;
 			std::vector<RleData> rleBuf;

--- a/Sources/Draw/SW/SWRenderer.cpp
+++ b/Sources/Draw/SW/SWRenderer.cpp
@@ -285,16 +285,12 @@ namespace spades {
 					auto* db2 = db;
 
 					for (int x = lightWidth; x > 0; x--) {
-						Vector3 pos;
+						float pz = *db2;
+						float dz = pz - lightCenter.z;
+						float dx = vx2 * pz - lightCenter.x;
+						float dy = vy * pz - lightCenter.y;
 
-						pos.z = *db2;
-						pos.x = vx2 * pos.z;
-						pos.y = vy * pos.z;
-
-						pos -= lightCenter;
-
-						float dist = pos.GetSquaredLength();
-						dist *= invRadius2;
+						float dist = (dx * dx + dy * dy + dz * dz) * invRadius2;
 
 						if (dist < 1.0F) {
 							float strength = 1.0F - dist;


### PR DESCRIPTION
## Summary

Brings in a set of upstream SW renderer and logging fixes, excluding one commit that adds debug/trap instrumentation not appropriate for production.

## Changes

- **sw: optimize raycaster hot path in SWMapRenderer/SWRenderer** — early-exit the DDA march once a scanline is fully filled, skip shading for zero-width RLE spans, cache resolved line/pitch constants per column instead of per-pixel, hoist per-frame z/height lookup tables out of the per-line pass, and flatten the dynamic-light distance math.
- **sw: remove dead branch in RenderFinal block loop** — drops a `goto` that jumped straight into the label on the next line; no behavior change.
- **sw: add opaque fast path to SSE2 solid-fill blending** — skips SIMD unpack/mul/pack work when a polygon is fully opaque, since the blend math already collapses to a plain overwrite in that case. Output is unchanged, just cheaper to produce.
- **fix: rate-limit log file I/O to prevent frame freezes** — `SPLog` no longer does a disk write + flush on every line; lines are buffered and flushed at most once/sec or at 64KB, with a final flush on shutdown. Also preloads the rifle sight textures to remove a lazy-load hitch on first ADS.


## Testing

Ran this locally before opening the PR. FPS is up slightly, though the raycaster/SSE2 changes aren't a dramatic win on their own. The more noticeable fix is the log I/O change: the game used to freeze for about a second at unpredictable times, and that no longer happens with this branch.