### PR TITLE
gl: fix outline pass PolygonMode core-profile violation and CullFace …

### DIFF
--- a/Sources/Draw/OpenGL/GLRenderer.cpp
+++ b/Sources/Draw/OpenGL/GLRenderer.cpp
@@ -677,7 +677,10 @@ namespace spades {
 				device->Enable(IGLDevice::CullFace, true);
 				device->CullFaceMode(IGLDevice::Front);
 				device->Enable(IGLDevice::PolygonOffsetLine, true);
-				device->PolygonMode(IGLDevice::Back, IGLDevice::Line);
+				// Front faces are culled above, so only back faces rasterize; use
+				// FRONT_AND_BACK (the only value accepted by a core profile — GL_BACK
+				// raises GL_INVALID_ENUM every frame on macOS) for the same result.
+				device->PolygonMode(IGLDevice::FrontAndBack, IGLDevice::Line);
 				device->PolygonOffset(1.0F, 1.0F);
 				device->LineWidth(2.0F);
 
@@ -686,8 +689,12 @@ namespace spades {
 				modelRenderer->RenderOutlinePass();
 
 				device->CullFaceMode(IGLDevice::Back);
+				// Restore CullFace to the renderer's resting (disabled) state — the
+				// pass enabled it above but previously never restored the enable,
+				// leaking cull state into whatever ran next.
+				device->Enable(IGLDevice::CullFace, false);
 				device->Enable(IGLDevice::PolygonOffsetLine, false);
-				device->PolygonMode(IGLDevice::Back, IGLDevice::Fill);
+				device->PolygonMode(IGLDevice::FrontAndBack, IGLDevice::Fill);
 				device->PolygonOffset(0.0F, 0.0F);
 				device->LineWidth(1.0F);
 			}


### PR DESCRIPTION
Enabling r_outlines (object outline) caused a framerate drop that didn't recover after disabling it. Two bugs in the outline pass were responsible.

Causes

- Leaked cull state (the sticky slowdown). The outline pass did Enable(CullFace, true) but on cleanup only restored the cull mode, never the enable. So the first time outlines ran, CullFace was left enabled for every following pass — and it stayed that way even after outlines were turned back off, which is why disabling didn't fix the framerate.

- Invalid glPolygonMode(GL_BACK, …) on the core profile. The wireframe used GL_BACK, which a core profile (e.g. macOS) rejects with GL_INVALID_ENUM — raised every frame while outlines were on, and the intended wireframe silently never applied.

Solution

- Restore CullFace to the renderer's resting (disabled) state at the end of the pass, so it no longer leaks into subsequent passes/frames.

- Use GL_FRONT_AND_BACK instead of GL_BACK for PolygonMode. Front faces are already culled, so it's the same result but valid on all profiles — no more per-frame GL errors.

Note: On macOS this makes the intended hardware wireframe actually take effect (it was previously ignored). LineWidth(2.0) is still above the core-profile guaranteed 1.0 and clamps to 1px on macOS; left as-is to avoid changing outline thickness elsewhere.