### PR TITLE
Add Release Notes for `v0.0.9` in AppStream File

### DIFF
--- a/flatpak/io.github.zerospades.ZeroSpades.metainfo.xml
+++ b/flatpak/io.github.zerospades.ZeroSpades.metainfo.xml
@@ -61,6 +61,43 @@
   </screenshots>
 
   <releases>
+    <release version="0.0.9" date="2026-08-03" url="https://github.com/zerospades/zerospades/releases/tag/v0.0.9">
+      <description>
+        <p>What's changed</p>
+        <ul>
+          <li>Added mod manager: download, enable/disable and apply official mods directly from the <em>Mods</em> tab in the main screen.</li>
+          <li>Added demo recording/replaying (Check its Wiki page!). (#13)</li>
+          <li>Added pie menu for quick communication thought chat messages. (#15)</li>
+          <li>Added circular and rotating mode for the minimap (currently only available for OpenGL renderer).</li>
+          <li>Added navigation bar in Preferences window, displaying buttons for each heading in the active tab. (#30)</li>
+          <li>Remember selected tab and scroll position in in-game settings (#36).</li>
+          <li>Added Compatible Mods button linking to zerospades-paks repository.</li>
+          <li>Added viewmodel position presets (Default, Balanced, Minimal).</li>
+          <li>Added warning alert when taking water damage.</li>
+          <li>Added support for MessageTypes extension.</li>
+          <li>Added application architecture in client version response.</li>
+          <li>Added riscv64 support (#28).</li>
+          <li>Improved Windows version detection (should correctly detect Windows 10/11 now).</li>
+          <li>Improved left-handed view by correctly mirroring models and animations.</li>
+          <li>Fixed flatpak packages (#51).</li>
+          <li>Fixed a bug that prevented the landing sound from playing when taking fall damage.</li>
+          <li>Fixed a bug in the PlayerProperties extension that caused an incorrect player score. (#35).</li>
+          <li>Fixed wrong message color code value (#40).</li>
+          <li>Fixed a bug that prevented players from placing blocks under them when jumping (#47).</li>
+          <li>Fixed an issue with shadows being rendered through walls when SSAO was enabled (yvt/openspades#862).</li>
+          <li>Fixed shotgun spam and highlight critical hits for damage numbers.</li>
+          <li>Ragdoll removal limits now configurable via <code>cg_corpseSoftLimit</code> and <code>cg_corpseHardLimit</code>.</li>
+          <li>Prevent multiline/newlines on text fields, player names and chat messages.</li>
+          <li>AngelScript has been updated from <code>v2.31.1</code> to <code>v2.38.0</code>.</li>
+          <li>OpenAL has been updated to OpenAL-soft.</li>
+          <li>YSR audio backend has been removed due to lack of use and it no longer being maintained.</li>
+        </ul>
+        <p>Additionally, users playing in non-Latin languages (such as Russian, Chinese, Greek, Arabic, etc.)
+        are encouraged to download NotoFonts.pak. It contains beautifully designed Roboto and Noto Fonts,
+        which cover all languages supported by ZeroSpades. It can be installed via the Mods tab in the main
+        screen, or manually by copying it to the Resource directory.</p>
+      </description>
+    </release>
     <release version="0.0.8" date="2025-12-25" url="https://github.com/zerospades/zerospades/releases/tag/v0.0.8">
       <description>
         <p>Highlights:</p>


### PR DESCRIPTION
Adds release notes for `v0.0.9` in the AppStream file.

Once this is merged, I'll remove the downstream `metainfo.patch` and publish `v0.0.9` to Flathub.