### PR TITLE
make player orientation smoothing framerate-independent

### DIFF
--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -87,7 +87,6 @@ namespace spades {
 			  readyToClose(false),
 
 			  worldSubFrame(0.0F),
-			  worldSubFrameFast(0.0F),
 			  frameToRendererInit(5),
 			  timeSinceInit(0.0F),
 			  hasLastTool(false),
@@ -232,7 +231,6 @@ namespace spades {
 			inGameLimbo = false;
 
 			worldSubFrame = 0.0F;
-			worldSubFrameFast = 0.0F;
 			worldSetTime = time;
 		}
 

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -145,7 +145,6 @@ namespace spades {
 			float time;
 			bool readyToClose;
 			float worldSubFrame;
-			float worldSubFrameFast;
 
 			int frameToRendererInit;
 			float timeSinceInit;

--- a/Sources/Client/Client_Update.cpp
+++ b/Sources/Client/Client_Update.cpp
@@ -316,24 +316,19 @@ namespace spades {
 #else
 				// accurately resembles server's physics
 				// but not smooth
-				if (gameplayDt > 0.0F) {
+				if (gameplayDt > 0.0F)
 					worldSubFrame += gameplayDt;
-					worldSubFrameFast += gameplayDt;
-				}
 
-				// these run at exactly ~60fps
+				// physics runs at exactly ~60fps to stay in step with the server
 				float frameStep = 1.0F / 60.0F;
 				while (worldSubFrame >= frameStep) {
-					world->Advance(frameStep); // physics update
+					world->Advance(frameStep);
 					worldSubFrame -= frameStep;
 				}
 
-				// these run at min. ~60fps but as fast as possible
-				float step = std::min(gameplayDt, frameStep);
-				while (worldSubFrameFast >= step) {
-					world->UpdatePlayer(step, false); // smooth orientation update
-					worldSubFrameFast -= step;
-				}
+				// orientation smoothing is presentation only and settles at a rate
+				// independent of the call rate, so one call per frame is enough
+				world->UpdatePlayersSmooth(gameplayDt);
 #endif
 				// update player view (doesn't affect physics/game logics)
 				for (const auto& clientPlayer : clientPlayers) {

--- a/Sources/Client/Player.cpp
+++ b/Sources/Client/Player.cpp
@@ -64,6 +64,7 @@ namespace spades {
 			velocity = MakeVector3(0, 0, 0);
 			orientation = MakeVector3((tId == 1) ? -1.0F : 1.0F, 0, 0);
 			orientationSmoothed = orientation;
+			hasNetworkOrientation = false;
 			moveDistance = 0.0F;
 			moveSteps = 0;
 
@@ -337,6 +338,15 @@ namespace spades {
 			SPADES_MARK_FUNCTION();
 
 			orientation = v;
+
+			// Players are constructed facing their team's default direction, which
+			// is unrelated to where they actually spawn looking. Adopt the first
+			// reported orientation outright so that arbitrary heading is never
+			// smoothed through on screen.
+			if (!hasNetworkOrientation) {
+				orientationSmoothed = v;
+				hasNetworkOrientation = true;
+			}
 		}
 
 		void Player::Turn(float longitude, float latitude) {

--- a/Sources/Client/Player.cpp
+++ b/Sources/Client/Player.cpp
@@ -40,6 +40,15 @@ DEFINE_SPADES_SETTING(cg_classicWeaponRecoil, "1");
 namespace spades {
 	namespace client {
 
+		// Time for a remote player's rendered orientation to cover half of the
+		// distance to the one the server last reported. Larger is smoother but lags
+		// further behind; this value reproduces the rate the filter settled at back
+		// when the game happened to run at exactly 60fps, which is what it was
+		// originally tuned against.
+		constexpr float kOrientationSmoothingHalfLife = 0.11F;
+		static_assert(kOrientationSmoothingHalfLife > 0.0F,
+					  "half-life drives a division and must be positive");
+
 		Player::Player(World& w, int pId, WeaponType wType, int tId) : world(w) {
 			SPADES_MARK_FUNCTION();
 
@@ -357,12 +366,36 @@ namespace spades {
 		void Player::UpdateSmooth(float dt) {
 			SPADES_MARK_FUNCTION();
 
-			// Smooth the player orientation
-			if (!IsLocalPlayer()) {
-				orientationSmoothed = orientationSmoothed * powf(0.9F, dt * 60.0F) +
-									  orientation * powf(0.1F, dt * 60.0F);
-				orientationSmoothed = orientationSmoothed.Normalize();
+			// The local player aims with the mouse, not with the network; filtering
+			// it would show up directly as crosshair lag.
+			if (IsLocalPlayer())
+				return;
+
+			if (!(dt > 0.0F))
+				return; // paused, or a degenerate frame time
+
+			// Exponential filter expressed as a half-life: half of the error between
+			// the smoothed and the networked orientation is removed every
+			// kOrientationSmoothingHalfLife seconds. Deriving the blend factor from
+			// the time actually elapsed, rather than assuming a fixed step, is what
+			// keeps the settling rate identical no matter how often this is called.
+			float const blend = 1.0F - powf(0.5F, dt / kOrientationSmoothingHalfLife);
+
+			// Near-antipodal orientations have no meaningful linear interpolation:
+			// the blend passes through the origin and the direction is lost. Snap,
+			// which is also the sanest depiction of an instant about-face.
+			if (Vector3::Dot(orientationSmoothed, orientation) <= -0.999F) {
+				orientationSmoothed = orientation;
+				return;
 			}
+
+			orientationSmoothed += (orientation - orientationSmoothed) * blend;
+
+			// Guard the renormalization: a collapsed blend would otherwise leave a
+			// zero vector behind and every consumer would inherit it.
+			float const length = orientationSmoothed.GetLength();
+			orientationSmoothed =
+			  (length > 0.0F) ? orientationSmoothed * (1.0F / length) : orientation;
 		}
 
 		void Player::Update(float dt) {

--- a/Sources/Client/Player.h
+++ b/Sources/Client/Player.h
@@ -74,6 +74,7 @@ namespace spades {
 			Vector3 velocity;
 			Vector3 orientation;
 			Vector3 orientationSmoothed;
+			bool hasNetworkOrientation;
 			Vector3 eye;
 			PlayerInput input;
 			WeaponInput weapInput;

--- a/Sources/Client/World.cpp
+++ b/Sources/Client/World.cpp
@@ -60,15 +60,17 @@ namespace spades {
 			return numPlayers;
 		}
 
-		void World::UpdatePlayer(float dt, bool locked) {
+		void World::UpdatePlayers(float dt) {
 			for (const auto& p : players) {
-				if (p && !p->IsSpectator()) {
-					if (locked) {
-						p->Update(dt);
-					} else {
-						p->UpdateSmooth(dt);
-					}
-				}
+				if (p && !p->IsSpectator())
+					p->Update(dt);
+			}
+		}
+
+		void World::UpdatePlayersSmooth(float dt) {
+			for (const auto& p : players) {
+				if (p && !p->IsSpectator())
+					p->UpdateSmooth(dt);
 			}
 		}
 
@@ -77,7 +79,7 @@ namespace spades {
 
 			ApplyBlockActions();
 
-			UpdatePlayer(dt, true);
+			UpdatePlayers(dt);
 
 			while (!damagedBlocksQueue.empty()) {
 				auto it = damagedBlocksQueue.begin();

--- a/Sources/Client/World.h
+++ b/Sources/Client/World.h
@@ -106,7 +106,12 @@ namespace spades {
 			IntVector3 GetFogColor() { return fogColor; }
 			void SetFogColor(IntVector3 v) { fogColor = v; }
 
-			void UpdatePlayer(float dt, bool locked);
+			/** Steps player physics and game logic. Must be driven at the fixed
+			 * rate the server simulates at, or the client will diverge from it. */
+			void UpdatePlayers(float dt);
+			/** Advances view-only orientation smoothing for remote players. Safe to
+			 * drive at any rate; it affects presentation, not simulation. */
+			void UpdatePlayersSmooth(float dt);
 			void Advance(float dt);
 
 			void AddGrenade(std::unique_ptr<Grenade>);


### PR DESCRIPTION
While digging into a question about how our "smooth player orientation
interpolation" actually works, I noticed the filter isn't framerate-independent.

`Player::UpdateSmooth` blended with two independently computed weights:

    orientationSmoothed = orientationSmoothed * powf(0.9F, dt * 60.0F) +
                          orientation * powf(0.1F, dt * 60.0F);

Those weights only sum to 1 at exactly `dt == 1/60`. At any other step they
don't, so the normalize afterwards hides the error in magnitude but not in
rate. The `worldSubFrameFast` substep loop in `UpdateWorld` clamped the step to
bound that error, but it couldn't remove it.

This is not a subtle deviation. Solving the effective time constant:

| framerate | before | after  |
|-----------|--------|--------|
| 60 fps    | 158 ms | 158 ms |
| 144 fps   | ~21 ms | 158 ms |
| 240 fps   |  ~9 ms | 158 ms |

The bug was quietly giving high-framerate players *much lighter* smoothing than
the feature was tuned for, which is likely why it felt good and nobody reported
it. Deriving the blend from elapsed time fixes the inconsistency, but it means
anyone above 60fps will now see remote players' aim trail more than it does
today. I kept the rate at the 60fps-equivalent (`kOrientationSmoothingHalfLife
= 0.11`) so nobody loses smoothing; that constant is the single tuning point if
we decide the tradeoff should go the other way after playtesting.

**This is not cosmetic.** The smoothed orientation feeds client-authoritative
hit detection, not just rendering: `FireWeapon` → `GetHitBoxes(interp)` →
`BulletHitPlayer` → `NetClient::SendHit`. Changing the smoothing rate changes
which body part the client reports hitting, so the table above is a gameplay
change and wants real playtesting rather than just a look.

Also folded in, each as its own commit:

- Smoothing is driven once per frame via `World::UpdatePlayersSmooth`, replacing
  the `UpdatePlayer(dt, bool locked)` boolean parameter with two named methods.
  This drops `worldSubFrameFast` (it only existed to bound the error above) and
  stops discarding the sub-step remainder each frame. It also removes a latent
  spin: the old loop had `step = min(gameplayDt, 1/60)`, so a `gameplayDt` of 0
  would have looped forever subtracting 0. Not reachable today — `SDLRunner`
  gates on `dt > 0` and demo speeds come from a nonzero preset table.
- `SetOrientation` adopts the first orientation the server reports instead of
  smoothing towards it. Players are constructed facing their team's default
  direction, so every spawn was smoothing through an arbitrary heading — an
  artifact this change would otherwise have stretched from ~60 ms to ~475 ms.
- Guards on the degenerate cases: near-antipodal orientations snap rather than
  nlerping through the origin, and the renormalization no longer leaves a zero
  vector behind if the blend collapses. `dt <= 0` is now an early return; the
  old code did a 50% blend on a zero-length step, since `powf(x, 0)` is 1 for
  both weights.

Still nlerp, so composition is approximate rather than exact — a true fix would
slerp. The residual is well below anything visible.

No new cvars and no UI changes; `cg_orientationSmoothing` still toggles the
whole thing.
