### PR TITLE
Prepare synchronous flashlight (if one day...)

### DIFF
--- a/Resources/Shaders/OpenGL/DynamicLight/Common.fs
+++ b/Resources/Shaders/OpenGL/DynamicLight/Common.fs
@@ -45,8 +45,18 @@ varying vec3 lightNormal;
 varying vec3 lightTexCoord;
 
 vec3 EvaluateDynamicLightNoBump() {
-	if (lightTexCoord.z < 0.0 || any(lessThan(lightTexCoord.xy, vec2(0.0))) ||
-	    any(greaterThan(lightTexCoord.xy, vec2(lightTexCoord.z))))
+	// Discard fragments behind the light source
+	if (lightTexCoord.z <= 0.0)
+		discard;
+
+	// Soft cone edge instead of hard discard. The projected coordinates span
+	// [0, 1] with the cone axis at (0.5, 0.5), so measure from there and
+	// rescale to 1.0 at the cone edge.
+	vec2 coneCoord = lightTexCoord.xy / lightTexCoord.z - vec2(0.5);
+	float coneDistance = length(coneCoord) * 2.0;
+	// Smooth falloff at cone edge (0.8 to 1.1 normalized)
+	float coneFalloff = smoothstep(1.1, 0.8, coneDistance);
+	if (coneFalloff <= 0.0)
 		discard;
 
 	// diffuse lighting
@@ -62,7 +72,7 @@ vec3 EvaluateDynamicLightNoBump() {
 	float attenuation = distance * distance;
 
 	// apply attenuation
-	intensity *= attenuation;
+	intensity *= attenuation * coneFalloff;
 
 	vec3 texValue = texture2DProj(dynamicLightProjectionTexture, lightTexCoord).xyz;
 

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -114,7 +114,6 @@ namespace spades {
 			  scoreboardVisible(false),
 			  netgraphVisible(false),
 			  hudVisible(true),
-			  flashlightOn(false),
 			  isChristmasOn(false),
 			  lastSnowDropTime(0.0F),
 			  hotBarIconState(0.0F),
@@ -194,7 +193,6 @@ namespace spades {
 			aimingDownSight = false;
 			reloadKeyPressed = false;
 			scoreboardVisible = false;
-			flashlightOn = false;
 			debugHitTestZoom = false;
 			spectatorZoom = false;
 			largeMapView->SetZoom(false);

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -309,8 +309,6 @@ namespace spades {
 			bool scoreboardVisible;
 			bool netgraphVisible;
 			bool hudVisible;
-			bool flashlightOn;
-			float flashlightOnTime;
 
 			struct GrenadeTracer {
 				std::vector<Vector3> positions;

--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -652,17 +652,17 @@ namespace spades {
 			Player& p = player;
 			IRenderer& renderer = client.GetRenderer();
 
-			// Remote players are lit whenever cg_everyoneFlashlight is set; the local
-			// player keeps the manual toggle.
-			const bool isRemote = !p.IsLocalPlayer();
-			if (isRemote ? !cg_everyoneFlashlight : !client.flashlightOn)
+			// Every player is lit from the same per-player state, which only the local
+			// player can toggle until the synchronous flashlight extension lands.
+			// cg_everyoneFlashlight overrides it for remote players, so the extension
+			// can be previewed without a server that speaks it.
+			const bool forced = cg_everyoneFlashlight && !p.IsLocalPlayer();
+			if (!p.IsFlashlightOn() && !forced)
 				return;
 
-			float brightness = 1.0F;
-			if (!isRemote) { // fade in when the local player turns it on
-				brightness = client.time - client.flashlightOnTime;
-				brightness = 1.0F - expf(-brightness * 5.0F);
-			}
+			// Fade in when the flashlight is switched on.
+			float brightness = p.GetWorld().GetTime() - p.GetFlashlightOnTime();
+			brightness = 1.0F - expf(-brightness * 5.0F);
 			brightness *= r_hdr ? 3.0F : 1.5F;
 
 			const std::array<Vector3, 3> axes = GetFlashlightAxes();

--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -465,9 +465,8 @@ namespace spades {
 				}
 			}
 
-			Vector3 front = player.GetFront();
-
 			if (!isThirdPerson) {
+				Vector3 front = player.GetFront();
 				Vector3 right = player.GetRight();
 				Vector3 up = player.GetUp();
 
@@ -528,12 +527,16 @@ namespace spades {
 				}
 			}
 
-			// Smooth the flashlight's movement (for all players)
-			Vector3 diff = front - flashlightOrientation;
+			// Smooth the flashlight's movement (for all players). Follow the same
+			// interpolated orientation the head is rendered from, so a remote player's
+			// cone doesn't lead their head and snap on every network update.
+			// `GetFront` returns the raw orientation for the local player either way.
+			Vector3 lightFront = player.GetFront(cg_orientationSmoothing);
+			Vector3 diff = lightFront - flashlightOrientation;
 			float dist = diff.GetLength();
 			if (dist > 0.1F)
 				flashlightOrientation += diff.Normalize() * (dist - 0.1F);
-			flashlightOrientation = Mix(flashlightOrientation, front, 1.0F - powf(1.0E-6F, dt));
+			flashlightOrientation = Mix(flashlightOrientation, lightFront, 1.0F - powf(1.0E-6F, dt));
 			flashlightOrientation = flashlightOrientation.Normalize();
 
 			// FIXME: should do for non-active skins?
@@ -641,9 +644,18 @@ namespace spades {
 		}
 
 		std::array<Vector3, 3> ClientPlayer::GetFlashlightAxes() {
+			// Roll the cone around its own direction rather than around the player's
+			// raw up vector: the two are equivalent while the player faces the way the
+			// lamp points, but the raw one snaps with every network update and is
+			// undefined when looking straight up or down.
+			static const Vector3 worldUp = MakeVector3(0, 0, -1);
+
 			std::array<Vector3, 3> axes;
 			axes[2] = flashlightOrientation;
-			axes[0] = Vector3::Cross(axes[2], player.GetUp()).Normalize();
+			axes[0] = Vector3::Cross(axes[2], worldUp);
+			if (axes[0].GetSquaredLength() < 1.0E-6F) // pointing straight up or down
+				axes[0] = Vector3::Cross(axes[2], MakeVector3(0, 1, 0));
+			axes[0] = axes[0].Normalize();
 			axes[1] = Vector3::Cross(axes[0], axes[2]);
 			return axes;
 		}

--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -686,12 +686,6 @@ namespace spades {
 				Handle<IImage> img = renderer.RegisterImage("Gfx/Spotlight.jpg");
 				light.image = img.GetPointerOrNull();
 				renderer.AddLight(light);
-
-				light.type = DynamicLightTypePoint;
-				light.radius = 10.0F;
-				light.color *= 0.3F;
-				light.image = nullptr;
-				renderer.AddLight(light);
 			}
 
 			Vector3 leftHand, rightHand;

--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -660,6 +660,19 @@ namespace spades {
 			return axes;
 		}
 
+		bool ClientPlayer::IsLampBuried(const Vector3& lightOrigin) {
+			World* world = client.GetWorld();
+			if (!world)
+				return false;
+
+			GameMap* map = world->GetMap().GetPointerOrNull();
+			if (!map)
+				return false;
+
+			IntVector3 block = lightOrigin.Floor();
+			return map->IsSolidWrapped(block.x, block.y, block.z);
+		}
+
 		void ClientPlayer::AddFlashlightToScene(const Vector3& lightOrigin) {
 			Player& p = player;
 			IRenderer& renderer = client.GetRenderer();
@@ -677,25 +690,13 @@ namespace spades {
 			brightness = 1.0F - expf(-brightness * 5.0F);
 			brightness *= r_hdr ? 3.0F : 1.5F;
 
-			const std::array<Vector3, 3> axes = GetFlashlightAxes();
-
-			// A lamp buried in geometry would light the far side of the block it
-			// sits in, since spotlights aren't shadowed.
-			if (World* world = client.GetWorld()) {
-				if (GameMap* map = world->GetMap().GetPointerOrNull()) {
-					IntVector3 block = lightOrigin.Floor();
-					if (map->IsSolidWrapped(block.x, block.y, block.z))
-						return;
-				}
-			}
-
 			DynamicLightParam light;
 			light.type = DynamicLightTypeSpotlight;
 			light.origin = lightOrigin;
 			light.radius = 60.0F;
 			light.color = MakeVector3(1.0F, 0.7F, 0.5F) * brightness;
 			light.spotAngle = DEG2RAD(90);
-			light.spotAxis = axes;
+			light.spotAxis = GetFlashlightAxes();
 			Handle<IImage> img = renderer.RegisterImage("Gfx/Spotlight.jpg");
 			light.image = img.GetPointerOrNull();
 			renderer.AddLight(light);
@@ -1285,8 +1286,10 @@ namespace spades {
 				}
 			}
 
-			// Roughly head height, so the lamp isn't buried in the torso.
-			AddFlashlightToScene(origin + Vector3(0.0F, 0.0F, -0.3F));
+			// Emit from the eye, so the lamp matches the first-person one and doesn't
+			// shift when the observer changes camera mode or the player crouches.
+			if (!IsLampBuried(p.GetEye()))
+				AddFlashlightToScene(p.GetEye());
 
 			// third person player rendering, done
 		}

--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -464,8 +464,9 @@ namespace spades {
 				}
 			}
 
+			Vector3 front = player.GetFront();
+
 			if (!isThirdPerson) {
-				Vector3 front = player.GetFront();
 				Vector3 right = player.GetRight();
 				Vector3 up = player.GetUp();
 
@@ -524,17 +525,15 @@ namespace spades {
 						softLimitFunc(viewWeaponOffset.z, 0, limitY);
 					}
 				}
-
-				// Smooth the flashlight's movement
-				if (client.flashlightOn && isLocalPlayer) {
-					Vector3 diff = front - flashlightOrientation;
-					float dist = diff.GetLength();
-					if (dist > 0.1F)
-						flashlightOrientation += diff.Normalize() * (dist - 0.1F);
-					flashlightOrientation = Mix(flashlightOrientation, front, 1.0F - powf(1.0E-6F, dt));
-					flashlightOrientation = flashlightOrientation.Normalize();
-				}
 			}
+
+			// Smooth the flashlight's movement (for all players)
+			Vector3 diff = front - flashlightOrientation;
+			float dist = diff.GetLength();
+			if (dist > 0.1F)
+				flashlightOrientation += diff.Normalize() * (dist - 0.1F);
+			flashlightOrientation = Mix(flashlightOrientation, front, 1.0F - powf(1.0E-6F, dt));
+			flashlightOrientation = flashlightOrientation.Normalize();
 
 			// FIXME: should do for non-active skins?
 			asIScriptObject* curSkin = GetCurrentSkin(!isThirdPerson);

--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -53,6 +53,7 @@
 SPADES_SETTING(cg_ragdoll);
 DEFINE_SPADES_SETTING(cg_animations, "1");
 SPADES_SETTING(cg_shake);
+SPADES_SETTING(cg_everyoneFlashlight);
 SPADES_SETTING(r_hdr);
 DEFINE_SPADES_SETTING(cg_environmentalAudio, "1");
 DEFINE_SPADES_SETTING(cg_classicPlayerModels, "0");
@@ -647,6 +648,47 @@ namespace spades {
 			return axes;
 		}
 
+		void ClientPlayer::AddFlashlightToScene(const Vector3& lightOrigin) {
+			Player& p = player;
+			IRenderer& renderer = client.GetRenderer();
+
+			// Remote players are lit whenever cg_everyoneFlashlight is set; the local
+			// player keeps the manual toggle.
+			const bool isRemote = !p.IsLocalPlayer();
+			if (isRemote ? !cg_everyoneFlashlight : !client.flashlightOn)
+				return;
+
+			float brightness = 1.0F;
+			if (!isRemote) { // fade in when the local player turns it on
+				brightness = client.time - client.flashlightOnTime;
+				brightness = 1.0F - expf(-brightness * 5.0F);
+			}
+			brightness *= r_hdr ? 3.0F : 1.5F;
+
+			const std::array<Vector3, 3> axes = GetFlashlightAxes();
+
+			// A lamp buried in geometry would light the far side of the block it
+			// sits in, since spotlights aren't shadowed.
+			if (World* world = client.GetWorld()) {
+				if (GameMap* map = world->GetMap().GetPointerOrNull()) {
+					IntVector3 block = lightOrigin.Floor();
+					if (map->IsSolidWrapped(block.x, block.y, block.z))
+						return;
+				}
+			}
+
+			DynamicLightParam light;
+			light.type = DynamicLightTypeSpotlight;
+			light.origin = lightOrigin;
+			light.radius = 60.0F;
+			light.color = MakeVector3(1.0F, 0.7F, 0.5F) * brightness;
+			light.spotAngle = DEG2RAD(90);
+			light.spotAxis = axes;
+			Handle<IImage> img = renderer.RegisterImage("Gfx/Spotlight.jpg");
+			light.image = img.GetPointerOrNull();
+			renderer.AddLight(light);
+		}
+
 		void ClientPlayer::AddToSceneFirstPersonView() {
 			Player& p = player;
 			Weapon& w = p.GetWeapon();
@@ -668,24 +710,8 @@ namespace spades {
 			sandboxedRenderer->SetClipBox(clip);
 			sandboxedRenderer->SetAllowDepthHack(true); // allow depthhack
 
-			// no flashlight if spectating other players while dead
-			if (client.flashlightOn && p.IsLocalPlayer()) {
-				float brightness = client.time - client.flashlightOnTime;
-				brightness = 1.0F - expf(-brightness * 5.0F);
-				brightness *= r_hdr ? 3.0F : 1.5F;
-
-				// add flash light
-				DynamicLightParam light;
-				light.type = DynamicLightTypeSpotlight;
-				light.origin = eyeMatrix.GetOrigin();
-				light.radius = 60.0F;
-				light.color = MakeVector3(1.0F, 0.7F, 0.5F) * brightness;
-				light.spotAngle = DEG2RAD(90);
-				light.spotAxis = GetFlashlightAxes();
-				Handle<IImage> img = renderer.RegisterImage("Gfx/Spotlight.jpg");
-				light.image = img.GetPointerOrNull();
-				renderer.AddLight(light);
-			}
+			// This path also runs for a remote player the camera is following.
+			AddFlashlightToScene(eyeMatrix.GetOrigin());
 
 			Vector3 leftHand, rightHand;
 			leftHand = MakeVector3(0, 0, 0);
@@ -1246,6 +1272,9 @@ namespace spades {
 					renderer.RenderModel(*model, param);
 				}
 			}
+
+			// Roughly head height, so the lamp isn't buried in the torso.
+			AddFlashlightToScene(origin + Vector3(0.0F, 0.0F, -0.3F));
 
 			// third person player rendering, done
 		}

--- a/Sources/Client/ClientPlayer.h
+++ b/Sources/Client/ClientPlayer.h
@@ -78,6 +78,13 @@ namespace spades {
 			std::array<Vector3, 3> GetFlashlightAxes();
 
 			/**
+			 * Whether a lamp at `lightOrigin` sits inside a solid voxel, in which case
+			 * it would light the far side of that block, since spotlights aren't
+			 * shadowed. Only meaningful for a lamp the camera isn't standing at.
+			 */
+			bool IsLampBuried(const Vector3& lightOrigin);
+
+			/**
 			 * Emit this player's flashlight from `lightOrigin`, if it should be lit
 			 * at all. Shared by the first- and third-person paths, which differ only
 			 * in where the lamp sits.

--- a/Sources/Client/ClientPlayer.h
+++ b/Sources/Client/ClientPlayer.h
@@ -76,6 +76,14 @@ namespace spades {
 			Handle<SandboxedRenderer> sandboxedRenderer;
 
 			std::array<Vector3, 3> GetFlashlightAxes();
+
+			/**
+			 * Emit this player's flashlight from `lightOrigin`, if it should be lit
+			 * at all. Shared by the first- and third-person paths, which differ only
+			 * in where the lamp sits.
+			 */
+			void AddFlashlightToScene(const Vector3& lightOrigin);
+
 			void AddToSceneThirdPersonView();
 			void AddToSceneFirstPersonView();
 

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -1024,8 +1024,7 @@ namespace spades {
 				} else if (CheckKey(cg_keyFlashlight, name) && down) {
 					// spectators and dead players shouldn't be able to toggle the flashlight
 					if (!localPlayerIsSpectator && localPlayerIsAlive) {
-						flashlightOn = !flashlightOn;
-						flashlightOnTime = time;
+						p.SetFlashlightOn(!p.IsFlashlightOn());
 						Handle<IAudioChunk> c =
 						  audioDevice->RegisterSound("Sounds/Player/Flashlight.opus");
 						audioDevice->PlayLocal(c.GetPointerOrNull(), AudioParam());

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -96,6 +96,8 @@ DEFINE_SPADES_SETTING(cg_switchToolByWheel, "1");
 DEFINE_SPADES_SETTING(cg_debugCorpse, "0");
 DEFINE_SPADES_SETTING(cg_keySpawnCorpse, "p");
 
+DEFINE_SPADES_SETTING(cg_everyoneFlashlight, "0");
+
 DEFINE_SPADES_SETTING(cg_keyPieMenu, "MiddleMouseButton");
 
 SPADES_SETTING(cg_manualFocus);

--- a/Sources/Client/Player.cpp
+++ b/Sources/Client/Player.cpp
@@ -50,6 +50,8 @@ namespace spades {
 			alive = true;
 			airborne = false;
 			wade = false;
+			flashlightOn = false;
+			flashlightOnTime = -100.0F;
 			position = MakeVector3(0, 0, 0);
 			eye = position;
 			velocity = MakeVector3(0, 0, 0);
@@ -94,6 +96,16 @@ namespace spades {
 		Player::~Player() { SPADES_MARK_FUNCTION(); }
 
 		bool Player::IsLocalPlayer() { return world.GetLocalPlayer() == this; }
+
+		void Player::SetFlashlightOn(bool on) {
+			SPADES_MARK_FUNCTION();
+
+			if (flashlightOn == on)
+				return;
+
+			flashlightOn = on;
+			flashlightOnTime = world.GetTime();
+		}
 
 		void Player::SetInput(PlayerInput newInput) {
 			SPADES_MARK_FUNCTION();

--- a/Sources/Client/Player.h
+++ b/Sources/Client/Player.h
@@ -80,6 +80,8 @@ namespace spades {
 			bool alive;
 			bool airborne;
 			bool wade;
+			bool flashlightOn;
+			float flashlightOnTime;
 			ToolType tool;
 
 			WeaponType weaponType;
@@ -192,6 +194,20 @@ namespace spades {
 			bool IsToolBlock() { return tool == ToolBlock; }
 			bool IsToolWeapon() { return tool == ToolWeapon; }
 			bool IsToolGrenade() { return tool == ToolGrenade; }
+
+			/**
+			 * Whether this player's flashlight is lit.
+			 *
+			 * Only the local player can toggle it for now, so it stays `false` for
+			 * everyone else. The state lives on the player rather than on the client
+			 * so that the future synchronous flashlight extension can drive it from
+			 * the network for local and remote players alike.
+			 */
+			bool IsFlashlightOn() { return flashlightOn; }
+			void SetFlashlightOn(bool on);
+
+			/** World time at which the flashlight last changed state, for the fade-in. */
+			float GetFlashlightOnTime() { return flashlightOnTime; }
 
 			bool IsZoomed() { return tool == ToolWeapon && weapInput.secondary; }
 			bool IsWalking() { return input.moveForward || input.moveBackward || input.moveLeft || input.moveRight; }


### PR DESCRIPTION
Hi,
This PR is here to prepare for a future synchronous flashlight extension.
It does:

- Soft, axis-centred cone edge for dynamic spotlights (OpenGL DynamicLight/Common.fs), replacing the hard cut whose falloff was measured from a corner — it lit one quadrant of the cone and discarded the opposite one. Also drops the omnidirectional point light that was emitted alongside the spotlight.

- flashlightOrientation is now smoothed for every player instead of only the local one, which is what makes remote flashlights possible at all.

- Both the first- and third-person paths emit through one ClientPlayer::AddFlashlightToScene(lightOrigin), differing only in where the lamp sits. Since that first-person path runs for whichever player the camera follows, this also fixes the flashlight being invisible when spectating a remote player. Emission is skipped when the lamp is inside a solid voxel, which would otherwise light the far side of its block (spotlights aren't shadowed).

- New `cg_everyoneFlashlight` cvar (default 0) forces the flashlight on for all non-local players; the local player keeps the F-key toggle.


Idk when such extension will be available/worked out BUT then, we will be ready!